### PR TITLE
Add macOS CI (swift build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (macOS, Swift 6)
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Show toolchain
+        run: swift --version
+
+      - name: Resolve dependencies
+        run: swift package resolve
+
+      - name: Build
+        run: swift build -v


### PR DESCRIPTION
## Context

Establishes a real build signal for the phased PicoDocs rewrite. Because the package links Apple-only frameworks (PDFKit / UniformTypeIdentifiers / WebKit), it can't be compiled in the Linux environment I'm working in — so without CI, the larger upcoming PRs (converter registry, detection, OOXML, etc.) would only be checked by Codex/Gemini, which don't compile code. This workflow closes that gap.

## What it does

- Runs on `pull_request` (any branch) and `push` to `main`, plus manual `workflow_dispatch`.
- `macos-15` runner, latest stable Xcode (Swift 6), `swift package resolve` + `swift build -v`.
- `concurrency` with `cancel-in-progress` so superseded runs are cancelled (saves macOS Actions minutes).

## Scope / follow-ups

- **Build-only for now.** `swift test` is intentionally not run yet: the current `ReadabilityTests` exercise a `WKWebView`/JS path that is slated for removal, and headless-CI behavior of `WKWebView` is unreliable. Test execution will be enabled as the suite is rebuilt around the new converters (Tier A).
- Multi-platform compilation (iOS/tvOS/visionOS via `xcodebuild` destinations) can be layered on later — useful for catching platform gaps like PDFKit's absence on tvOS.

https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP)_