### PR TITLE
Phase 2: HTML → Markdown converter

### DIFF
--- a/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
+++ b/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
@@ -50,6 +50,7 @@ public struct DocumentConverterRegistry: Sendable {
 
     static func makeDefault() -> DocumentConverterRegistry {
         DocumentConverterRegistry()
+            .registering(HTMLConverter(), priority: Priority.specific)
             .registering(PlainTextConverter(), priority: Priority.generic)
     }
 

--- a/Sources/PicoDocs/Converters/HTML/HTMLConverter.swift
+++ b/Sources/PicoDocs/Converters/HTML/HTMLConverter.swift
@@ -18,7 +18,9 @@ public struct HTMLConverter: DocumentConverter {
     }
 
     public func convert(_ data: Data, info: StreamInfo) async throws -> ConverterResult {
-        let encoding = info.charset ?? .utf8
+        // Prefer the caller/detector charset, then a document-declared charset
+        // (`<meta charset=...>`), then UTF-8.
+        let encoding = info.charset ?? Self.sniffHTMLCharset(data) ?? .utf8
         let decoded = String(data: data, encoding: encoding)
             ?? (encoding != .utf8 ? String(data: data, encoding: .utf8) : nil)
         guard let html = decoded else {
@@ -32,5 +34,23 @@ public struct HTMLConverter: DocumentConverter {
 
         let section = DocumentSection(title: title, kind: .body, markdown: markdown)
         return ConverterResult(title: title, sections: [section])
+    }
+
+    /// Sniffs a document-declared charset (`<meta charset="...">` or
+    /// `<meta http-equiv="Content-Type" content="...; charset=...">`) from the
+    /// raw bytes, so non-UTF-8 HTML that declares its encoding internally decodes
+    /// correctly. Reads a Latin-1 view of the head (which always succeeds) to
+    /// locate the declaration without needing the encoding up front.
+    static func sniffHTMLCharset(_ data: Data) -> String.Encoding? {
+        guard let head = String(data: data.prefix(2048), encoding: .isoLatin1) else { return nil }
+        let lower = head.lowercased()
+        guard let range = lower.range(of: "charset=") else { return nil }
+        let name = lower[range.upperBound...]
+            .drop { $0 == "\"" || $0 == "'" || $0 == " " }
+            .prefix { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" || $0 == "." }
+        guard !name.isEmpty else { return nil }
+        let cfEncoding = CFStringConvertIANACharSetNameToEncoding(String(name) as CFString)
+        guard cfEncoding != kCFStringEncodingInvalidId else { return nil }
+        return String.Encoding(rawValue: CFStringConvertEncodingToNSStringEncoding(cfEncoding))
     }
 }

--- a/Sources/PicoDocs/Converters/HTML/HTMLConverter.swift
+++ b/Sources/PicoDocs/Converters/HTML/HTMLConverter.swift
@@ -1,0 +1,36 @@
+//
+//  HTMLConverter.swift
+//  PicoDocs
+//
+//  Converts HTML to Markdown via the pure-Swift SwiftSoup walker. Replaces the
+//  old behavior where HTML was returned as raw markup (issue #2). Reader-mode
+//  cleanup (Readability) is a separate, optional pass added later.
+//
+
+import Foundation
+
+public struct HTMLConverter: DocumentConverter {
+
+    public init() {}
+
+    public func accepts(_ info: StreamInfo) -> Bool {
+        info.detectedFormat == .html
+    }
+
+    public func convert(_ data: Data, info: StreamInfo) async throws -> ConverterResult {
+        let encoding = info.charset ?? .utf8
+        let decoded = String(data: data, encoding: encoding)
+            ?? (encoding != .utf8 ? String(data: data, encoding: .utf8) : nil)
+        guard let html = decoded else {
+            throw ConverterError.decodingFailed
+        }
+
+        let (title, markdown) = try HTMLToMarkdown.convert(html: html, baseURI: info.url?.absoluteString)
+        guard !markdown.isEmpty else {
+            throw PicoDocsError.emptyDocument
+        }
+
+        let section = DocumentSection(title: title, kind: .body, markdown: markdown)
+        return ConverterResult(title: title, sections: [section])
+    }
+}

--- a/Sources/PicoDocs/Converters/HTML/HTMLToMarkdown.swift
+++ b/Sources/PicoDocs/Converters/HTML/HTMLToMarkdown.swift
@@ -159,9 +159,14 @@ enum HTMLToMarkdown {
             let cells = tr.children().array().filter { ["td", "th"].contains($0.tagName().lowercased()) }
             guard !cells.isEmpty else { continue }
             rows.append(cells.map { cell in
-                ((try? cell.text()) ?? "")
-                    .replacingOccurrences(of: "|", with: "\\|")
+                // Render the cell's children through the walker so inline links /
+                // images / emphasis survive; collapse to a single line (table
+                // cells can't contain newlines) and escape pipes.
+                var rendered = ""
+                renderChildren(of: cell, into: &rendered)
+                return collapseWhitespace(rendered)
                     .trimmingCharacters(in: .whitespaces)
+                    .replacingOccurrences(of: "|", with: "\\|")
             })
         }
         guard !rows.isEmpty else { return "" }

--- a/Sources/PicoDocs/Converters/HTML/HTMLToMarkdown.swift
+++ b/Sources/PicoDocs/Converters/HTML/HTMLToMarkdown.swift
@@ -1,0 +1,178 @@
+//
+//  HTMLToMarkdown.swift
+//  PicoDocs
+//
+//  Converts an HTML document to Markdown by walking the SwiftSoup DOM directly —
+//  no NSAttributedString round-trip (which was lossy and main-thread-bound).
+//  Synchronous and Sendable-friendly; reused by the EPUB converter later.
+//
+
+import Foundation
+import SwiftSoup
+
+enum HTMLToMarkdown {
+
+    /// Parses `html` and renders its `<body>` to Markdown, returning the document
+    /// title (from `<title>`) when present. `baseURI` resolves relative links.
+    static func convert(html: String, baseURI: String? = nil) throws -> (title: String?, markdown: String) {
+        let document = try SwiftSoup.parse(html, baseURI ?? "")
+        let title = (try? document.title()).flatMap { $0.isEmpty ? nil : $0 }
+        let root: Node = document.body() ?? document
+        var out = ""
+        renderChildren(of: root, into: &out)
+        let markdown = normalizeBlankLines(out).trimmingCharacters(in: .whitespacesAndNewlines)
+        return (title, markdown)
+    }
+
+    // MARK: - Walking
+
+    private static func renderChildren(of node: Node, into out: inout String) {
+        for child in node.getChildNodes() {
+            render(child, into: &out)
+        }
+    }
+
+    /// Renders an element's children to a trimmed inline string.
+    private static func inlineString(_ element: Element) -> String {
+        var s = ""
+        renderChildren(of: element, into: &s)
+        return collapseWhitespace(s).trimmingCharacters(in: .whitespaces)
+    }
+
+    private static func render(_ node: Node, into out: inout String) {
+        if let text = node as? TextNode {
+            out += collapseWhitespace(text.getWholeText())
+            return
+        }
+        guard let element = node as? Element else { return }
+
+        switch element.tagName().lowercased() {
+        case "script", "style", "noscript", "head", "title", "meta", "link", "svg":
+            return // non-content
+
+        case "h1", "h2", "h3", "h4", "h5", "h6":
+            let level = Int(element.tagName().dropFirst()) ?? 1
+            let text = inlineString(element)
+            if !text.isEmpty { out += "\n\n\(String(repeating: "#", count: level)) \(text)\n\n" }
+
+        case "br":
+            out += "  \n"
+
+        case "hr":
+            out += "\n\n---\n\n"
+
+        case "strong", "b":
+            let t = inlineString(element)
+            if !t.isEmpty { out += "**\(t)**" }
+
+        case "em", "i":
+            let t = inlineString(element)
+            if !t.isEmpty { out += "*\(t)*" }
+
+        case "code":
+            if element.parent()?.tagName().lowercased() == "pre" {
+                renderChildren(of: element, into: &out) // inside a fenced block
+            } else {
+                let t = (try? element.text()) ?? ""
+                if !t.isEmpty { out += "`\(t)`" }
+            }
+
+        case "pre":
+            let code = (try? element.text()) ?? ""
+            out += "\n\n```\n\(code)\n```\n\n"
+
+        case "a":
+            let text = inlineString(element)
+            let href = (try? element.attr("href")) ?? ""
+            out += (href.isEmpty || text.isEmpty) ? text : "[\(text)](\(href))"
+
+        case "img":
+            let alt = (try? element.attr("alt")) ?? ""
+            let src = (try? element.attr("src")) ?? ""
+            if !src.isEmpty { out += "![\(alt)](\(src))" }
+
+        case "ul":
+            out += "\n\n" + renderList(element, ordered: false) + "\n\n"
+
+        case "ol":
+            out += "\n\n" + renderList(element, ordered: true) + "\n\n"
+
+        case "blockquote":
+            var inner = ""
+            renderChildren(of: element, into: &inner)
+            let quoted = normalizeBlankLines(inner)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .components(separatedBy: "\n")
+                .map { $0.isEmpty ? ">" : "> \($0)" }
+                .joined(separator: "\n")
+            if !quoted.isEmpty { out += "\n\n\(quoted)\n\n" }
+
+        case "table":
+            let table = renderTable(element)
+            if !table.isEmpty { out += "\n\n\(table)\n\n" }
+
+        case "p", "div", "section", "article", "main", "header", "footer", "figure", "figcaption":
+            out += "\n\n"
+            renderChildren(of: element, into: &out)
+            out += "\n\n"
+
+        default:
+            renderChildren(of: element, into: &out)
+        }
+    }
+
+    private static func renderList(_ element: Element, ordered: Bool) -> String {
+        var lines: [String] = []
+        var index = 1
+        for child in element.children().array() where child.tagName().lowercased() == "li" {
+            var itemBody = ""
+            renderChildren(of: child, into: &itemBody)
+            let text = normalizeBlankLines(itemBody).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { continue }
+            let marker = ordered ? "\(index). " : "- "
+            let indent = String(repeating: " ", count: marker.count)
+            let rendered = text.components(separatedBy: "\n").enumerated().map { offset, line in
+                offset == 0 ? "\(marker)\(line)" : "\(indent)\(line)"
+            }.joined(separator: "\n")
+            lines.append(rendered)
+            index += 1
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func renderTable(_ element: Element) -> String {
+        var rows: [[String]] = []
+        let trs = (try? element.select("tr"))?.array() ?? []
+        for tr in trs {
+            let cells = tr.children().array().filter { ["td", "th"].contains($0.tagName().lowercased()) }
+            guard !cells.isEmpty else { continue }
+            rows.append(cells.map { cell in
+                ((try? cell.text()) ?? "")
+                    .replacingOccurrences(of: "|", with: "\\|")
+                    .trimmingCharacters(in: .whitespaces)
+            })
+        }
+        guard !rows.isEmpty else { return "" }
+        let columns = rows.map(\.count).max() ?? 0
+        func pad(_ row: [String]) -> [String] { row + Array(repeating: "", count: max(0, columns - row.count)) }
+        var md = "| " + pad(rows[0]).joined(separator: " | ") + " |\n"
+        md += "| " + Array(repeating: "---", count: columns).joined(separator: " | ") + " |"
+        for row in rows.dropFirst() {
+            md += "\n| " + pad(row).joined(separator: " | ") + " |"
+        }
+        return md
+    }
+
+    // MARK: - Whitespace
+
+    /// Collapses runs of whitespace (including newlines) to a single space, for
+    /// inline text where HTML treats all whitespace as equivalent.
+    private static func collapseWhitespace(_ s: String) -> String {
+        s.replacingOccurrences(of: "[ \\t\\r\\n\\f]+", with: " ", options: .regularExpression)
+    }
+
+    /// Collapses 3+ consecutive newlines down to a paragraph break.
+    private static func normalizeBlankLines(_ s: String) -> String {
+        s.replacingOccurrences(of: "\n{3,}", with: "\n\n", options: .regularExpression)
+    }
+}

--- a/Sources/PicoDocs/Converters/HTML/HTMLToMarkdown.swift
+++ b/Sources/PicoDocs/Converters/HTML/HTMLToMarkdown.swift
@@ -26,22 +26,24 @@ enum HTMLToMarkdown {
 
     // MARK: - Walking
 
-    private static func renderChildren(of node: Node, into out: inout String) {
+    private static func renderChildren(of node: Node, into out: inout String, preserveWhitespace: Bool = false) {
         for child in node.getChildNodes() {
-            render(child, into: &out)
+            render(child, into: &out, preserveWhitespace: preserveWhitespace)
         }
     }
 
-    /// Renders an element's children to a trimmed inline string.
+    /// Renders an element's children to a trimmed inline string (whitespace
+    /// collapsed — used for headings, links, emphasis, etc.).
     private static func inlineString(_ element: Element) -> String {
         var s = ""
         renderChildren(of: element, into: &s)
         return collapseWhitespace(s).trimmingCharacters(in: .whitespaces)
     }
 
-    private static func render(_ node: Node, into out: inout String) {
+    private static func render(_ node: Node, into out: inout String, preserveWhitespace: Bool = false) {
         if let text = node as? TextNode {
-            out += collapseWhitespace(text.getWholeText())
+            let whole = text.getWholeText()
+            out += preserveWhitespace ? whole : collapseWhitespace(whole)
             return
         }
         guard let element = node as? Element else { return }
@@ -71,24 +73,25 @@ enum HTMLToMarkdown {
 
         case "code":
             if element.parent()?.tagName().lowercased() == "pre" {
-                renderChildren(of: element, into: &out) // inside a fenced block
+                renderChildren(of: element, into: &out, preserveWhitespace: true) // inside a fenced block
             } else {
                 let t = (try? element.text()) ?? ""
                 if !t.isEmpty { out += "`\(t)`" }
             }
 
         case "pre":
-            let code = (try? element.text()) ?? ""
-            out += "\n\n```\n\(code)\n```\n\n"
+            out += "\n\n```\n"
+            renderChildren(of: element, into: &out, preserveWhitespace: true)
+            out += "\n```\n\n"
 
         case "a":
             let text = inlineString(element)
-            let href = (try? element.attr("href")) ?? ""
+            let href = resolvedURL(element, attribute: "href")
             out += (href.isEmpty || text.isEmpty) ? text : "[\(text)](\(href))"
 
         case "img":
             let alt = (try? element.attr("alt")) ?? ""
-            let src = (try? element.attr("src")) ?? ""
+            let src = resolvedURL(element, attribute: "src")
             if !src.isEmpty { out += "![\(alt)](\(src))" }
 
         case "ul":
@@ -99,7 +102,7 @@ enum HTMLToMarkdown {
 
         case "blockquote":
             var inner = ""
-            renderChildren(of: element, into: &inner)
+            renderChildren(of: element, into: &inner, preserveWhitespace: preserveWhitespace)
             let quoted = normalizeBlankLines(inner)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .components(separatedBy: "\n")
@@ -113,12 +116,21 @@ enum HTMLToMarkdown {
 
         case "p", "div", "section", "article", "main", "header", "footer", "figure", "figcaption":
             out += "\n\n"
-            renderChildren(of: element, into: &out)
+            renderChildren(of: element, into: &out, preserveWhitespace: preserveWhitespace)
             out += "\n\n"
 
         default:
-            renderChildren(of: element, into: &out)
+            renderChildren(of: element, into: &out, preserveWhitespace: preserveWhitespace)
         }
+    }
+
+    /// Resolves an element attribute to an absolute URL (against the parse base
+    /// URI), falling back to the raw attribute value when there's no base.
+    private static func resolvedURL(_ element: Element, attribute: String) -> String {
+        if let absolute = try? element.absUrl(attribute), !absolute.isEmpty {
+            return absolute
+        }
+        return (try? element.attr(attribute)) ?? ""
     }
 
     private static func renderList(_ element: Element, ordered: Bool) -> String {


### PR DESCRIPTION
## Context

First format converter on top of the Phase 1 engine. It closes the **"HTML did not do any conversion, raw html content"** half of issue #2: HTML is now converted to Markdown directly via a pure-Swift SwiftSoup DOM walk, with no `NSAttributedString` round-trip (which was lossy and main-thread-bound).

Scoped deliberately small (one converter) after Phase 1's long review loop.

## What's here

- **`HTMLToMarkdown`** — a recursive SwiftSoup DOM walker emitting Markdown: headings (`h1`–`h6`), `strong`/`em`, `a[href]` (resolved against the base URL), `ul`/`ol`/`li`, `blockquote`, `code`/`pre` fences, `img`, `hr`, and pipe `table`s. Skips `script`/`style`/`head`; collapses inline whitespace and excess blank lines. Returns the `<title>` too.
- **`HTMLConverter`** — `DocumentConverter` for `.html`, registered at **specific** priority (ahead of the generic `PlainTextConverter`). Decodes with the resolved charset and returns a structured `ConverterResult`.

## Notes / deferrals

- **Readability** (reader-mode cleanup — the pure-Swift scorer and the JavaScriptCore spike) is intentionally a **separate later PR**; this is the faithful full-document HTML→Markdown path.
- HTML *output* (`ExportFileType.html`) remains renderer-unsupported for now; Markdown is the canonical product.

## Verification

- macOS CI (`swift build`, Swift 6) gates this PR. I can't `swift build` in my Linux env, so CI is the compile signal; if the SwiftSoup API usage needs a tweak it'll surface there and I'll fix it in the loop.
- Converter unit tests (incl. an HTML→Markdown fixture and the issue-#2 detection guard) land when `swift test` is enabled in CI — after the legacy `WKWebView` Readability tests are removed (Phase 4).

https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP)_