### PR TITLE
Phase 3: EPUB converter (ZIPFoundation + HTMLToMarkdown)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
         .package(url: "https://github.com/CoreOffice/CoreXLSX", from: "0.14.2"),
         .package(url: "https://github.com/ronaldmannak/EPUBKit", branch: "main"),
         .package(url: "https://github.com/scinfu/SwiftSoup", from: "2.7.6"),
+        .package(url: "https://github.com/weichsel/ZIPFoundation.git", from: "0.9.19"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -35,6 +36,7 @@ let package = Package(
                 .product(name: "CoreXLSX", package: "CoreXLSX"),
                 .product(name: "EPUBKit", package: "EPUBKit"),
                 .product(name: "SwiftSoup", package: "SwiftSoup"),
+                .product(name: "ZIPFoundation", package: "ZIPFoundation"),
             ],
             resources: [
                 .process("Localizable.xcstrings"),

--- a/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
+++ b/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
@@ -52,6 +52,7 @@ public struct DocumentConverterRegistry: Sendable {
         DocumentConverterRegistry()
             .registering(HTMLConverter(), priority: Priority.specific)
             .registering(SpreadsheetConverter(), priority: Priority.specific)
+            .registering(EPUBConverter(), priority: Priority.specific)
             .registering(PlainTextConverter(), priority: Priority.generic)
     }
 

--- a/Sources/PicoDocs/Converters/EPUBConverter.swift
+++ b/Sources/PicoDocs/Converters/EPUBConverter.swift
@@ -1,0 +1,132 @@
+//
+//  EPUBConverter.swift
+//  PicoDocs
+//
+//  Converts EPUB to Markdown: unzip with ZIPFoundation, read the OPF for spine
+//  order + metadata, and render each chapter's XHTML through the shared
+//  HTMLToMarkdown walker. Fully in-memory (Data in), cross-platform, and free of
+//  the old EPUBKit + NSAttributedString path.
+//
+
+import Foundation
+import ZIPFoundation
+import SwiftSoup
+
+public struct EPUBConverter: DocumentConverter {
+
+    public init() {}
+
+    public func accepts(_ info: StreamInfo) -> Bool {
+        info.detectedFormat == .epub
+    }
+
+    public func convert(_ data: Data, info: StreamInfo) async throws -> ConverterResult {
+        guard let archive = Archive(data: data, accessMode: .read) else {
+            throw PicoDocsError.fileCorrupted
+        }
+
+        // 1. META-INF/container.xml -> path to the OPF package document.
+        guard let containerData = Self.readEntry(archive, path: "META-INF/container.xml"),
+              let containerXML = String(data: containerData, encoding: .utf8),
+              let opfPath = try Self.opfPath(fromContainer: containerXML) else {
+            throw PicoDocsError.fileCorrupted
+        }
+
+        // 2. Parse the OPF: metadata, manifest (id -> href), spine (order).
+        guard let opfData = Self.readEntry(archive, path: opfPath),
+              let opfXML = String(data: opfData, encoding: .utf8) else {
+            throw PicoDocsError.fileCorrupted
+        }
+        let opf = try SwiftSoup.parse(opfXML, "", SwiftSoup.Parser.xmlParser())
+        let opfDir = (opfPath as NSString).deletingLastPathComponent
+
+        let title = (try? opf.getElementsByTag("dc:title").first()?.text())
+            ?? (try? opf.getElementsByTag("title").first()?.text())
+        let author = (try? opf.getElementsByTag("dc:creator").first()?.text())
+            ?? (try? opf.getElementsByTag("creator").first()?.text())
+
+        var manifest: [String: String] = [:]
+        for item in (try? opf.getElementsByTag("item").array()) ?? [] {
+            guard let id = try? item.attr("id"), let href = try? item.attr("href"),
+                  !id.isEmpty, !href.isEmpty else { continue }
+            manifest[id] = href
+        }
+
+        // 3. Walk the spine in order, rendering each chapter to Markdown.
+        var sections: [DocumentSection] = []
+        for itemref in (try? opf.getElementsByTag("itemref").array()) ?? [] {
+            try Task.checkCancellation()
+            guard let idref = try? itemref.attr("idref"), let href = manifest[idref] else { continue }
+            let entryPath = Self.resolve(path: href, relativeTo: opfDir)
+            guard let chapterData = Self.readEntry(archive, path: entryPath),
+                  let chapterHTML = String(data: chapterData, encoding: .utf8) else { continue }
+            guard let (chapterTitle, markdown) = try? HTMLToMarkdown.convert(html: chapterHTML) else { continue }
+            let trimmed = markdown.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            sections.append(DocumentSection(
+                title: chapterTitle,
+                kind: .chapter,
+                markdown: trimmed,
+                sourcePath: entryPath
+            ))
+        }
+
+        guard !sections.isEmpty else { throw PicoDocsError.emptyDocument }
+
+        let resolvedTitle = (title?.isEmpty == false) ? title : info.filename
+        let cover = Self.coverData(archive: archive, opf: opf, manifest: manifest, opfDir: opfDir)
+        return ConverterResult(
+            title: resolvedTitle,
+            author: (author?.isEmpty == false) ? author : nil,
+            cover: cover,
+            sections: sections
+        )
+    }
+
+    // MARK: - Archive / OPF helpers
+
+    static func readEntry(_ archive: Archive, path: String) -> Data? {
+        guard let entry = archive[path] else { return nil }
+        var data = Data()
+        do {
+            _ = try archive.extract(entry) { data.append($0) }
+        } catch {
+            return nil
+        }
+        return data
+    }
+
+    static func opfPath(fromContainer xml: String) throws -> String? {
+        let doc = try SwiftSoup.parse(xml, "", SwiftSoup.Parser.xmlParser())
+        guard let rootfile = try doc.getElementsByTag("rootfile").first(),
+              let path = try? rootfile.attr("full-path"), !path.isEmpty else {
+            return nil
+        }
+        return path
+    }
+
+    /// Resolves a manifest href (which is relative to the OPF's directory) to a
+    /// ZIP entry path, decoding percent-encoding and normalizing `..`/`.`.
+    static func resolve(path href: String, relativeTo dir: String) -> String {
+        let decoded = href.removingPercentEncoding ?? href
+        guard !dir.isEmpty else { return decoded }
+        let combined = (dir as NSString).appendingPathComponent(decoded)
+        return (combined as NSString).standardizingPath
+    }
+
+    /// Best-effort cover image lookup (EPUB3 `properties="cover-image"`, then
+    /// EPUB2 `<meta name="cover">`). Returns nil if not found.
+    static func coverData(archive: Archive, opf: Document, manifest: [String: String], opfDir: String) -> Data? {
+        let items = (try? opf.getElementsByTag("item").array()) ?? []
+        if let item = items.first(where: { ((try? $0.attr("properties")) ?? "").contains("cover-image") }),
+           let href = try? item.attr("href") {
+            return readEntry(archive, path: resolve(path: href, relativeTo: opfDir))
+        }
+        let metas = (try? opf.getElementsByTag("meta").array()) ?? []
+        if let meta = metas.first(where: { (try? $0.attr("name")) == "cover" }),
+           let coverId = try? meta.attr("content"), let href = manifest[coverId] {
+            return readEntry(archive, path: resolve(path: href, relativeTo: opfDir))
+        }
+        return nil
+    }
+}

--- a/Sources/PicoDocs/Converters/EPUBConverter.swift
+++ b/Sources/PicoDocs/Converters/EPUBConverter.swift
@@ -27,14 +27,14 @@ public struct EPUBConverter: DocumentConverter {
 
         // 1. META-INF/container.xml -> path to the OPF package document.
         guard let containerData = Self.readEntry(archive, path: "META-INF/container.xml"),
-              let containerXML = String(data: containerData, encoding: .utf8),
+              let containerXML = Self.decodeText(containerData),
               let opfPath = try Self.opfPath(fromContainer: containerXML) else {
             throw PicoDocsError.fileCorrupted
         }
 
         // 2. Parse the OPF: metadata, manifest (id -> href), spine (order).
         guard let opfData = Self.readEntry(archive, path: opfPath),
-              let opfXML = String(data: opfData, encoding: .utf8) else {
+              let opfXML = Self.decodeText(opfData) else {
             throw PicoDocsError.fileCorrupted
         }
         let opf = try SwiftSoup.parse(opfXML, "", SwiftSoup.Parser.xmlParser())
@@ -59,7 +59,7 @@ public struct EPUBConverter: DocumentConverter {
             guard let idref = try? itemref.attr("idref"), let href = manifest[idref] else { continue }
             let entryPath = Self.resolve(path: href, relativeTo: opfDir)
             guard let chapterData = Self.readEntry(archive, path: entryPath),
-                  let chapterHTML = String(data: chapterData, encoding: .utf8) else { continue }
+                  let chapterHTML = Self.decodeText(chapterData) else { continue }
             guard let (chapterTitle, markdown) = try? HTMLToMarkdown.convert(html: chapterHTML) else { continue }
             let trimmed = markdown.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { continue }
@@ -86,14 +86,24 @@ public struct EPUBConverter: DocumentConverter {
     // MARK: - Archive / OPF helpers
 
     static func readEntry(_ archive: Archive, path: String) -> Data? {
-        guard let entry = archive[path] else { return nil }
-        var data = Data()
+        // ZIP entries have no leading slash; strip one so resolved paths still match.
+        let cleanPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
+        guard let entry = archive[cleanPath] else { return nil }
+        var data = Data(capacity: Int(entry.uncompressedSize))
         do {
             _ = try archive.extract(entry) { data.append($0) }
         } catch {
             return nil
         }
         return data
+    }
+
+    /// Decodes text trying UTF-8, then UTF-16 (BOM-aware), then ISO Latin-1 as a
+    /// never-fails fallback, so non-UTF-8 EPUB parts aren't silently dropped.
+    static func decodeText(_ data: Data) -> String? {
+        if let utf8 = String(data: data, encoding: .utf8) { return utf8 }
+        if let utf16 = String(data: data, encoding: .utf16) { return utf16 }
+        return String(data: data, encoding: .isoLatin1)
     }
 
     static func opfPath(fromContainer xml: String) throws -> String? {


### PR DESCRIPTION
## Context

Phase 3, and the last of issue #2's reported-broken formats on the new engine. Replaces the old EPUBKit + `NSAttributedString` path (disk-oriented, lossy, main-thread-bound) with a pure-Swift, in-memory pipeline that reuses the `HTMLToMarkdown` walker from PR #6.

## What's here

- **`ZIPFoundation`** added as a **direct** dependency (it was already resolved transitively at `0.9.19` via EPUBKit, so no new download). EPUBKit stays for now — the legacy `ePubParser` still uses it until the Phase 4 cleanup.
- **`EPUBConverter`** (`.epub`, specific priority):
  - unzips in-memory (`Archive(data:)`),
  - reads `META-INF/container.xml` → OPF path,
  - parses the OPF (metadata, manifest, **spine order**) via SwiftSoup's XML parser,
  - renders each spine chapter's XHTML through the shared **`HTMLToMarkdown`** walker → one `.chapter` `DocumentSection` each (with `sourcePath`),
  - best-effort cover extraction (EPUB3 `properties="cover-image"`, EPUB2 `<meta name="cover">`).

## Notes

- Cross-platform and `Data`-in (works on iOS/server), unlike the old disk-walking EPUBKit path.
- `..`/percent-encoded hrefs are normalized when resolving manifest paths to ZIP entries.

## Verification

- macOS CI (`swift package resolve` + `swift build`, Swift 6) gates this — it's the compile check for the ZIPFoundation API usage (`Archive(data:)`, `extract`, subscript), which I couldn't build locally.
- Converter unit tests (with a tiny `.epub` fixture) land when `swift test` is enabled (Phase 4).

https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP)_