### PR TITLE
EPUB: non-linear spine + portable path normalization (Codex #8 follow-up)

### DIFF
--- a/Sources/PicoDocs/Converters/EPUBConverter.swift
+++ b/Sources/PicoDocs/Converters/EPUBConverter.swift
@@ -125,16 +125,17 @@ public struct EPUBConverter: DocumentConverter {
         // Normalize "."/".." against the OPF directory manually. These are logical
         // ZIP entry paths, not filesystem paths, so avoid NSString.standardizingPath
         // (filesystem-aware and platform-dependent for relative paths) and resolve
-        // the components ourselves.
-        var components: [String] = dir.isEmpty ? [] : dir.split(separator: "/").map(String.init)
-        for part in decoded.split(separator: "/").map(String.init) {
+        // the components ourselves. A leading "/" is root-relative, so ignore dir.
+        let startsWithSlash = decoded.hasPrefix("/")
+        var components: [String] = (dir.isEmpty || startsWithSlash) ? [] : dir.split(separator: "/").map(String.init)
+        for part in decoded.split(separator: "/") {
             switch part {
-            case "", ".":
+            case ".":
                 continue
             case "..":
                 if !components.isEmpty { components.removeLast() }
             default:
-                components.append(part)
+                components.append(String(part))
             }
         }
         return components.joined(separator: "/")

--- a/Sources/PicoDocs/Converters/EPUBConverter.swift
+++ b/Sources/PicoDocs/Converters/EPUBConverter.swift
@@ -56,6 +56,9 @@ public struct EPUBConverter: DocumentConverter {
         var sections: [DocumentSection] = []
         for itemref in (try? opf.getElementsByTag("itemref").array()) ?? [] {
             try Task.checkCancellation()
+            // Skip non-linear spine items: auxiliary content (popups, end matter,
+            // alternate views) that's outside the primary reading order.
+            if (try? itemref.attr("linear"))?.lowercased() == "no" { continue }
             guard let idref = try? itemref.attr("idref"), let href = manifest[idref] else { continue }
             let entryPath = Self.resolve(path: href, relativeTo: opfDir)
             guard let chapterData = Self.readEntry(archive, path: entryPath),
@@ -119,9 +122,22 @@ public struct EPUBConverter: DocumentConverter {
     /// ZIP entry path, decoding percent-encoding and normalizing `..`/`.`.
     static func resolve(path href: String, relativeTo dir: String) -> String {
         let decoded = href.removingPercentEncoding ?? href
-        guard !dir.isEmpty else { return decoded }
-        let combined = (dir as NSString).appendingPathComponent(decoded)
-        return (combined as NSString).standardizingPath
+        // Normalize "."/".." against the OPF directory manually. These are logical
+        // ZIP entry paths, not filesystem paths, so avoid NSString.standardizingPath
+        // (filesystem-aware and platform-dependent for relative paths) and resolve
+        // the components ourselves.
+        var components: [String] = dir.isEmpty ? [] : dir.split(separator: "/").map(String.init)
+        for part in decoded.split(separator: "/").map(String.init) {
+            switch part {
+            case "", ".":
+                continue
+            case "..":
+                if !components.isEmpty { components.removeLast() }
+            default:
+                components.append(part)
+            }
+        }
+        return components.joined(separator: "/")
     }
 
     /// Best-effort cover image lookup (EPUB3 `properties="cover-image"`, then


### PR DESCRIPTION
## Context

Follow-up to @chatgpt-codex-connector's review on #8, which landed just after that PR merged. Addresses the two valid items as new improvements to `EPUBConverter` (the other two: OPF/encoding-beyond-UTF-8 was already fixed in #8's `473e392`; chapter-relative-link base is deferred — see below).

## Changes

- **Skip non-linear spine items** — spine `itemref`s with `linear="no"` are auxiliary content (popups, alternate views, end matter) outside the primary reading order. They were being injected into the main Markdown; now skipped.
- **Portable path normalization** — `resolve(path:relativeTo:)` now collapses `.`/`..` segments manually for the logical ZIP entry path, instead of `NSString.standardizingPath` (which is filesystem-aware and platform-dependent for relative paths). So an OPF href like `Text/../chapter.xhtml` resolves to the correct entry rather than a path the archive lookup misses.

## Deferred (with reasoning)

- **Chapter-relative link base** (passing a `baseURI` to `HTMLToMarkdown` per chapter): EPUB internal links/images have no meaningful *external* base, and we don't emit the referenced in-archive assets, so a relative link stays a dangling reference whether or not it's normalized to an internal path. Synthesizing a base produces non-useful absolute paths. Leaving internal links relative is acceptable; can revisit if a use case needs internal cross-references rewritten.

## Verification

- macOS CI (`swift build`, Swift 6).

https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP)_