### PR TITLE
Phase 3: DOCX (Word) converter

### DIFF
--- a/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
+++ b/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
@@ -53,6 +53,7 @@ public struct DocumentConverterRegistry: Sendable {
             .registering(HTMLConverter(), priority: Priority.specific)
             .registering(SpreadsheetConverter(), priority: Priority.specific)
             .registering(EPUBConverter(), priority: Priority.specific)
+            .registering(WordConverter(), priority: Priority.specific)
             .registering(PlainTextConverter(), priority: Priority.generic)
     }
 

--- a/Sources/PicoDocs/Converters/WordConverter.swift
+++ b/Sources/PicoDocs/Converters/WordConverter.swift
@@ -59,7 +59,7 @@ public struct WordConverter: DocumentConverter {
                 let table = renderTable(element, relationships: relationships)
                 if !table.isEmpty { blocks.append(table) }
             case "w:sdt":
-                if let content = element.getElementsByTag("w:sdtContent").first() {
+                if let content = try? element.getElementsByTag("w:sdtContent").first() {
                     blocks.append(contentsOf: try renderBlocks(in: content, relationships: relationships))
                 }
             default:
@@ -73,7 +73,7 @@ public struct WordConverter: DocumentConverter {
 
     static func renderParagraph(_ paragraph: Element, relationships: [String: String]) -> String? {
         let style = try? paragraph.getElementsByTag("w:pStyle").first()?.attr("w:val")
-        let isListItem = paragraph.getElementsByTag("w:numPr").first() != nil
+        let isListItem = (try? paragraph.getElementsByTag("w:numPr").first()) != nil
         let text = renderInline(paragraph, relationships: relationships).trimmingCharacters(in: .whitespaces)
         guard !text.isEmpty else { return nil }
 
@@ -146,7 +146,7 @@ public struct WordConverter: DocumentConverter {
         }
         guard !text.isEmpty else { return "" }
 
-        let properties = run.getElementsByTag("w:rPr").first()
+        let properties = try? run.getElementsByTag("w:rPr").first()
         var result = text
         if isFormattingEnabled(properties, tag: "w:b") { result = "**\(result)**" }
         if isFormattingEnabled(properties, tag: "w:i") { result = "*\(result)*" }
@@ -156,7 +156,7 @@ public struct WordConverter: DocumentConverter {
     /// True when a run-property toggle (`w:b`/`w:i`) is present and not explicitly
     /// disabled (`w:val="false"/"0"/"none"`, used to override style hierarchies).
     private static func isFormattingEnabled(_ properties: Element?, tag: String) -> Bool {
-        guard let element = properties?.getElementsByTag(tag).first() else { return false }
+        guard let element = try? properties?.getElementsByTag(tag).first() else { return false }
         if let val = try? element.attr("w:val"), !val.isEmpty {
             return val != "false" && val != "0" && val != "none"
         }
@@ -219,7 +219,7 @@ public struct WordConverter: DocumentConverter {
             return [:]
         }
         var map: [String: String] = [:]
-        for rel in doc.getElementsByTag("Relationship").array() {
+        for rel in (try? doc.getElementsByTag("Relationship").array()) ?? [] {
             guard let id = try? rel.attr("Id"), let target = try? rel.attr("Target"),
                   !id.isEmpty, !target.isEmpty else { continue }
             map[id] = target

--- a/Sources/PicoDocs/Converters/WordConverter.swift
+++ b/Sources/PicoDocs/Converters/WordConverter.swift
@@ -1,0 +1,209 @@
+//
+//  WordConverter.swift
+//  PicoDocs
+//
+//  Converts DOCX (OOXML WordprocessingML) to Markdown: unzip with ZIPFoundation,
+//  walk word/document.xml via SwiftSoup's XML parser, and map paragraph styles /
+//  runs / hyperlinks / tables to Markdown. Replaces the old NSAttributedString
+//  DOCX path (lossy, font-size heading guessing, and a hard throw on iOS).
+//
+
+import Foundation
+import ZIPFoundation
+import SwiftSoup
+
+public struct WordConverter: DocumentConverter {
+
+    public init() {}
+
+    public func accepts(_ info: StreamInfo) -> Bool {
+        info.detectedFormat == .docx
+    }
+
+    public func convert(_ data: Data, info: StreamInfo) async throws -> ConverterResult {
+        guard let archive = Archive(data: data, accessMode: .read) else {
+            throw PicoDocsError.fileCorrupted
+        }
+        guard let documentData = Self.readEntry(archive, path: "word/document.xml"),
+              let documentXML = Self.decodeText(documentData) else {
+            throw PicoDocsError.fileCorrupted
+        }
+
+        let relationships = Self.parseRelationships(archive)
+        let document = try SwiftSoup.parse(documentXML, "", SwiftSoup.Parser.xmlParser())
+        guard let body = try document.getElementsByTag("w:body").first() else {
+            throw PicoDocsError.emptyDocument
+        }
+
+        var blocks: [String] = []
+        for element in body.children().array() {
+            try Task.checkCancellation()
+            switch element.tagName().lowercased() {
+            case "w:p":
+                if let markdown = Self.renderParagraph(element, relationships: relationships), !markdown.isEmpty {
+                    blocks.append(markdown)
+                }
+            case "w:tbl":
+                let table = Self.renderTable(element, relationships: relationships)
+                if !table.isEmpty { blocks.append(table) }
+            default:
+                continue
+            }
+        }
+
+        let markdown = blocks.joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !markdown.isEmpty else { throw PicoDocsError.emptyDocument }
+        return ConverterResult(title: info.filename, sections: [DocumentSection(kind: .body, markdown: markdown)])
+    }
+
+    // MARK: - Paragraphs
+
+    static func renderParagraph(_ paragraph: Element, relationships: [String: String]) -> String? {
+        let style = try? paragraph.getElementsByTag("w:pStyle").first()?.attr("w:val")
+        let isListItem = paragraph.getElementsByTag("w:numPr").first() != nil
+        let text = renderInline(paragraph, relationships: relationships).trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty else { return nil }
+
+        if let level = headingLevel(forStyle: style) {
+            return String(repeating: "#", count: level) + " " + text
+        }
+        if isListItem {
+            return "- " + text
+        }
+        return text
+    }
+
+    static func headingLevel(forStyle style: String?) -> Int? {
+        guard let style = style?.lowercased() else { return nil }
+        if style == "title" { return 1 }
+        if style.hasPrefix("heading"), let n = Int(style.dropFirst("heading".count)) {
+            return min(max(n, 1), 6)
+        }
+        return nil
+    }
+
+    // MARK: - Inline content (runs, hyperlinks)
+
+    static func renderInline(_ container: Element, relationships: [String: String]) -> String {
+        var out = ""
+        for child in container.children().array() {
+            switch child.tagName().lowercased() {
+            case "w:ppr":
+                continue // paragraph properties, not content
+            case "w:r":
+                out += renderRun(child)
+            case "w:hyperlink":
+                let inner = renderInlineRuns(child)
+                let relId = (try? child.attr("r:id")) ?? ""
+                if let url = relationships[relId], !url.isEmpty, !inner.isEmpty {
+                    out += "[\(inner)](\(url))"
+                } else {
+                    out += inner
+                }
+            default:
+                // smartTag / ins / other wrappers: recurse for nested runs
+                out += renderInline(child, relationships: relationships)
+            }
+        }
+        return out
+    }
+
+    static func renderInlineRuns(_ container: Element) -> String {
+        var out = ""
+        for child in container.children().array() where child.tagName().lowercased() == "w:r" {
+            out += renderRun(child)
+        }
+        return out
+    }
+
+    static func renderRun(_ run: Element) -> String {
+        var text = ""
+        for node in run.children().array() {
+            switch node.tagName().lowercased() {
+            case "w:t":
+                // Use the raw text node to preserve significant whitespace
+                // (w:t may carry xml:space="preserve").
+                text += node.textNodes().first?.getWholeText() ?? ((try? node.text()) ?? "")
+            case "w:tab":
+                text += "\t"
+            case "w:br", "w:cr":
+                text += "  \n"
+            default:
+                continue
+            }
+        }
+        guard !text.isEmpty else { return "" }
+
+        let properties = run.getElementsByTag("w:rPr").first()
+        var result = text
+        if properties?.getElementsByTag("w:b").first() != nil { result = "**\(result)**" }
+        if properties?.getElementsByTag("w:i").first() != nil { result = "*\(result)*" }
+        return result
+    }
+
+    // MARK: - Tables
+
+    static func renderTable(_ table: Element, relationships: [String: String]) -> String {
+        var rows: [[String]] = []
+        for tr in table.children().array() where tr.tagName().lowercased() == "w:tr" {
+            var cells: [String] = []
+            for tc in tr.children().array() where tc.tagName().lowercased() == "w:tc" {
+                var cellText = ""
+                for paragraph in tc.children().array() where paragraph.tagName().lowercased() == "w:p" {
+                    let t = renderInline(paragraph, relationships: relationships).trimmingCharacters(in: .whitespaces)
+                    if !t.isEmpty { cellText += (cellText.isEmpty ? "" : " ") + t }
+                }
+                cells.append(cellText.replacingOccurrences(of: "|", with: "\\|"))
+            }
+            if !cells.isEmpty { rows.append(cells) }
+        }
+        guard !rows.isEmpty else { return "" }
+
+        let columns = rows.map(\.count).max() ?? 0
+        func pad(_ row: [String]) -> [String] { row + Array(repeating: "", count: max(0, columns - row.count)) }
+        var md = "| " + pad(rows[0]).joined(separator: " | ") + " |\n"
+        md += "| " + Array(repeating: "---", count: columns).joined(separator: " | ") + " |"
+        for row in rows.dropFirst() {
+            md += "\n| " + pad(row).joined(separator: " | ") + " |"
+        }
+        return md
+    }
+
+    // MARK: - Relationships (hyperlink targets)
+
+    static func parseRelationships(_ archive: Archive) -> [String: String] {
+        guard let data = readEntry(archive, path: "word/_rels/document.xml.rels"),
+              let xml = decodeText(data),
+              let doc = try? SwiftSoup.parse(xml, "", SwiftSoup.Parser.xmlParser()) else {
+            return [:]
+        }
+        var map: [String: String] = [:]
+        for rel in (try? doc.getElementsByTag("Relationship").array()) ?? [] {
+            guard let id = try? rel.attr("Id"), let target = try? rel.attr("Target"),
+                  !id.isEmpty, !target.isEmpty else { continue }
+            map[id] = target
+        }
+        return map
+    }
+
+    // MARK: - Archive helpers
+    // (mirror EPUBConverter's; candidates for a shared ZIP utility later.)
+
+    static func readEntry(_ archive: Archive, path: String) -> Data? {
+        let cleanPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
+        guard let entry = archive[cleanPath] else { return nil }
+        var data = Data(capacity: Int(entry.uncompressedSize))
+        do {
+            _ = try archive.extract(entry) { data.append($0) }
+        } catch {
+            return nil
+        }
+        return data
+    }
+
+    static func decodeText(_ data: Data) -> String? {
+        if let utf8 = String(data: data, encoding: .utf8) { return utf8 }
+        if let utf16 = String(data: data, encoding: .utf16) { return utf16 }
+        return String(data: data, encoding: .isoLatin1)
+    }
+}

--- a/Sources/PicoDocs/Converters/WordConverter.swift
+++ b/Sources/PicoDocs/Converters/WordConverter.swift
@@ -139,8 +139,10 @@ public struct WordConverter: DocumentConverter {
             case "w:br", "w:cr":
                 text += "  \n"
             default:
-                // NOTE: text-box content (w:drawing/w:pict -> w:txbxContent) and
-                // embedded images aren't extracted yet — a later enhancement.
+                // NOTE: text-box content (w:drawing/w:pict -> w:txbxContent),
+                // embedded images, and footnote/endnote references (whose text
+                // lives in word/footnotes.xml / endnotes.xml) aren't extracted
+                // yet — later enhancements.
                 continue
             }
         }
@@ -185,7 +187,9 @@ public struct WordConverter: DocumentConverter {
             var cells: [String] = []
             for tc in tr.children().array() where tc.tagName().lowercased() == "w:tc" {
                 var cellText = ""
-                for paragraph in tc.children().array() where paragraph.tagName().lowercased() == "w:p" {
+                // Gather all descendant paragraphs so paragraphs inside block
+                // content controls (w:sdt) within the cell are included too.
+                for paragraph in (try? tc.getElementsByTag("w:p").array()) ?? [] {
                     let t = renderInline(paragraph, relationships: relationships).trimmingCharacters(in: .whitespaces)
                     if !t.isEmpty { cellText += (cellText.isEmpty ? "" : "\n") + t }
                 }
@@ -195,6 +199,12 @@ public struct WordConverter: DocumentConverter {
                     .replacingOccurrences(of: "\r\n", with: "<br>")
                     .replacingOccurrences(of: "\r", with: "<br>")
                     .replacingOccurrences(of: "\n", with: "<br>"))
+                // Honor horizontally merged cells (w:gridSpan) so later columns
+                // stay aligned, by emitting empty placeholders for the span.
+                let span = gridSpan(of: tc)
+                if span > 1 {
+                    cells.append(contentsOf: Array(repeating: "", count: span - 1))
+                }
             }
             if !cells.isEmpty { rows.append(cells) }
         }
@@ -208,6 +218,13 @@ public struct WordConverter: DocumentConverter {
             md += "\n| " + pad(row).joined(separator: " | ") + " |"
         }
         return md
+    }
+
+    /// Number of grid columns a table cell spans (`w:gridSpan`); 1 if absent.
+    private static func gridSpan(of cell: Element) -> Int {
+        guard let value = try? cell.getElementsByTag("w:gridSpan").first()?.attr("w:val"),
+              let span = Int(value) else { return 1 }
+        return max(1, span)
     }
 
     // MARK: - Relationships (hyperlink targets)

--- a/Sources/PicoDocs/Converters/WordConverter.swift
+++ b/Sources/PicoDocs/Converters/WordConverter.swift
@@ -35,25 +35,38 @@ public struct WordConverter: DocumentConverter {
             throw PicoDocsError.emptyDocument
         }
 
+        let blocks = try Self.renderBlocks(in: body, relationships: relationships)
+        let markdown = blocks.joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !markdown.isEmpty else { throw PicoDocsError.emptyDocument }
+        return ConverterResult(title: info.filename, sections: [DocumentSection(kind: .body, markdown: markdown)])
+    }
+
+    // MARK: - Blocks
+
+    /// Renders the block-level children of a container (the body, or a content
+    /// control's content) to Markdown blocks, recursing into `w:sdt` content
+    /// controls (forms/templates wrap paragraphs and tables in them).
+    static func renderBlocks(in container: Element, relationships: [String: String]) throws -> [String] {
         var blocks: [String] = []
-        for element in body.children().array() {
+        for element in container.children().array() {
             try Task.checkCancellation()
             switch element.tagName().lowercased() {
             case "w:p":
-                if let markdown = Self.renderParagraph(element, relationships: relationships), !markdown.isEmpty {
+                if let markdown = renderParagraph(element, relationships: relationships), !markdown.isEmpty {
                     blocks.append(markdown)
                 }
             case "w:tbl":
-                let table = Self.renderTable(element, relationships: relationships)
+                let table = renderTable(element, relationships: relationships)
                 if !table.isEmpty { blocks.append(table) }
+            case "w:sdt":
+                if let content = element.getElementsByTag("w:sdtContent").first() {
+                    blocks.append(contentsOf: try renderBlocks(in: content, relationships: relationships))
+                }
             default:
                 continue
             }
         }
-
-        let markdown = blocks.joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !markdown.isEmpty else { throw PicoDocsError.emptyDocument }
-        return ConverterResult(title: info.filename, sections: [DocumentSection(kind: .body, markdown: markdown)])
+        return blocks
     }
 
     // MARK: - Paragraphs
@@ -76,8 +89,10 @@ public struct WordConverter: DocumentConverter {
     static func headingLevel(forStyle style: String?) -> Int? {
         guard let style = style?.lowercased() else { return nil }
         if style == "title" { return 1 }
-        if style.hasPrefix("heading"), let n = Int(style.dropFirst("heading".count)) {
-            return min(max(n, 1), 6)
+        if style.hasPrefix("heading") {
+            // Tolerate "heading1", "heading 1", "heading-1", etc.
+            let suffix = style.dropFirst("heading".count).filter { $0.isNumber }
+            if let n = Int(suffix) { return min(max(n, 1), 6) }
         }
         return nil
     }
@@ -93,25 +108,17 @@ public struct WordConverter: DocumentConverter {
             case "w:r":
                 out += renderRun(child)
             case "w:hyperlink":
-                let inner = renderInlineRuns(child)
+                let inner = renderInline(child, relationships: relationships)
                 let relId = (try? child.attr("r:id")) ?? ""
                 if let url = relationships[relId], !url.isEmpty, !inner.isEmpty {
-                    out += "[\(inner)](\(url))"
+                    out += "[\(escapeLinkLabel(inner))](\(escapeLinkDestination(url)))"
                 } else {
                     out += inner
                 }
             default:
-                // smartTag / ins / other wrappers: recurse for nested runs
+                // smartTag / ins / proofErr / other wrappers: recurse for nested runs.
                 out += renderInline(child, relationships: relationships)
             }
-        }
-        return out
-    }
-
-    static func renderInlineRuns(_ container: Element) -> String {
-        var out = ""
-        for child in container.children().array() where child.tagName().lowercased() == "w:r" {
-            out += renderRun(child)
         }
         return out
     }
@@ -121,14 +128,18 @@ public struct WordConverter: DocumentConverter {
         for node in run.children().array() {
             switch node.tagName().lowercased() {
             case "w:t":
-                // Use the raw text node to preserve significant whitespace
+                // Read raw text nodes to preserve significant whitespace
                 // (w:t may carry xml:space="preserve").
-                text += node.textNodes().first?.getWholeText() ?? ((try? node.text()) ?? "")
+                for child in node.getChildNodes() {
+                    if let textNode = child as? TextNode { text += textNode.getWholeText() }
+                }
             case "w:tab":
                 text += "\t"
             case "w:br", "w:cr":
                 text += "  \n"
             default:
+                // NOTE: text-box content (w:drawing/w:pict -> w:txbxContent) and
+                // embedded images aren't extracted yet — a later enhancement.
                 continue
             }
         }
@@ -136,9 +147,33 @@ public struct WordConverter: DocumentConverter {
 
         let properties = run.getElementsByTag("w:rPr").first()
         var result = text
-        if properties?.getElementsByTag("w:b").first() != nil { result = "**\(result)**" }
-        if properties?.getElementsByTag("w:i").first() != nil { result = "*\(result)*" }
+        if isFormattingEnabled(properties, tag: "w:b") { result = "**\(result)**" }
+        if isFormattingEnabled(properties, tag: "w:i") { result = "*\(result)*" }
         return result
+    }
+
+    /// True when a run-property toggle (`w:b`/`w:i`) is present and not explicitly
+    /// disabled (`w:val="false"/"0"/"none"`, used to override style hierarchies).
+    private static func isFormattingEnabled(_ properties: Element?, tag: String) -> Bool {
+        guard let element = properties?.getElementsByTag(tag).first() else { return false }
+        if let val = try? element.attr("w:val"), !val.isEmpty {
+            return val != "false" && val != "0" && val != "none"
+        }
+        return true
+    }
+
+    private static func escapeLinkLabel(_ text: String) -> String {
+        text.replacingOccurrences(of: "[", with: "\\[")
+            .replacingOccurrences(of: "]", with: "\\]")
+    }
+
+    private static func escapeLinkDestination(_ url: String) -> String {
+        // Spaces / parens break inline link destinations; wrap in <> (a valid
+        // CommonMark destination form) when present.
+        if url.contains(" ") || url.contains("(") || url.contains(")") {
+            return "<\(url)>"
+        }
+        return url
     }
 
     // MARK: - Tables
@@ -151,9 +186,14 @@ public struct WordConverter: DocumentConverter {
                 var cellText = ""
                 for paragraph in tc.children().array() where paragraph.tagName().lowercased() == "w:p" {
                     let t = renderInline(paragraph, relationships: relationships).trimmingCharacters(in: .whitespaces)
-                    if !t.isEmpty { cellText += (cellText.isEmpty ? "" : " ") + t }
+                    if !t.isEmpty { cellText += (cellText.isEmpty ? "" : "\n") + t }
                 }
-                cells.append(cellText.replacingOccurrences(of: "|", with: "\\|"))
+                // Single-line Markdown cells: escape pipes; CR/LF become <br>.
+                cells.append(cellText
+                    .replacingOccurrences(of: "|", with: "\\|")
+                    .replacingOccurrences(of: "\r\n", with: "<br>")
+                    .replacingOccurrences(of: "\r", with: "<br>")
+                    .replacingOccurrences(of: "\n", with: "<br>"))
             }
             if !cells.isEmpty { rows.append(cells) }
         }
@@ -178,7 +218,7 @@ public struct WordConverter: DocumentConverter {
             return [:]
         }
         var map: [String: String] = [:]
-        for rel in (try? doc.getElementsByTag("Relationship").array()) ?? [] {
+        for rel in doc.getElementsByTag("Relationship").array() {
             guard let id = try? rel.attr("Id"), let target = try? rel.attr("Target"),
                   !id.isEmpty, !target.isEmpty else { continue }
             map[id] = target

--- a/Sources/PicoDocs/Converters/WordConverter.swift
+++ b/Sources/PicoDocs/Converters/WordConverter.swift
@@ -90,9 +90,10 @@ public struct WordConverter: DocumentConverter {
         guard let style = style?.lowercased() else { return nil }
         if style == "title" { return 1 }
         if style.hasPrefix("heading") {
-            // Tolerate "heading1", "heading 1", "heading-1", etc.
-            let suffix = style.dropFirst("heading".count).filter { $0.isNumber }
-            if let n = Int(suffix) { return min(max(n, 1), 6) }
+            // Tolerate "heading1", "heading 1", "heading-1", etc. (filter returns
+            // [Character], so wrap in String before Int(_:)).
+            let digits = String(style.dropFirst("heading".count).filter { $0.isNumber })
+            if let n = Int(digits) { return min(max(n, 1), 6) }
         }
         return nil
     }


### PR DESCRIPTION
## Context

Phase 3b — the **last** of issue #2's reported-broken formats (docx) on the new engine. Replaces the old `NSAttributedString` DOCX path, which guessed headings from font point size and **threw outright on iOS**. This walks the real OOXML structure, cross-platform and in-memory.

## What's here

- **`WordConverter`** (`.docx`, specific priority) — ZIPFoundation + SwiftSoup's XML parser over `word/document.xml`:
  - paragraph styles → headings (`Heading1..6`, `Title`),
  - runs → **bold**/*italic* (`w:b`/`w:i`), preserving significant whitespace (`w:t` raw text),
  - `w:hyperlink` → `[text](url)` resolved via `word/_rels/document.xml.rels`,
  - `w:tbl` → Markdown tables (ragged-row padded, pipes escaped),
  - `w:numPr` → list items, `w:tab`/`w:br` handled.

## Notes / deferrals

- Lists use `-` bullets; ordered-vs-unordered + nesting (from `numbering.xml`/`w:ilvl`) is a later refinement.
- Images (`w:drawing`) are skipped for now (no placeholder) — asset extraction is future work.
- The ZIP `readEntry`/`decodeText` helpers mirror `EPUBConverter`'s; a shared ZIP utility is a reasonable later refactor (noted in code).
- Legacy `Parsers/Parser.swift` DOCX path stays until the Phase 4 cleanup.

## Verification

- macOS CI (`swift build`, Swift 6) — compile check for the SwiftSoup XML / ZIPFoundation usage.
- Converter unit tests (tiny `.docx` fixture) land when `swift test` is enabled (Phase 4).

https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP)_