### PR TITLE
Phase 2: PDF converter (PDFKit)

### DIFF
--- a/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
+++ b/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
@@ -49,12 +49,15 @@ public struct DocumentConverterRegistry: Sendable {
     public static let `default`: DocumentConverterRegistry = makeDefault()
 
     static func makeDefault() -> DocumentConverterRegistry {
-        DocumentConverterRegistry()
+        var registry = DocumentConverterRegistry()
             .registering(HTMLConverter(), priority: Priority.specific)
             .registering(SpreadsheetConverter(), priority: Priority.specific)
             .registering(EPUBConverter(), priority: Priority.specific)
             .registering(WordConverter(), priority: Priority.specific)
-            .registering(PlainTextConverter(), priority: Priority.generic)
+        #if canImport(PDFKit)
+        registry = registry.registering(PDFConverter(), priority: Priority.specific)
+        #endif
+        return registry.registering(PlainTextConverter(), priority: Priority.generic)
     }
 
     /// Convert `data` using the first accepting converter (ascending priority).

--- a/Sources/PicoDocs/Converters/PDFConverter.swift
+++ b/Sources/PicoDocs/Converters/PDFConverter.swift
@@ -1,0 +1,50 @@
+//
+//  PDFConverter.swift
+//  PicoDocs
+//
+//  Extracts text from PDFs via PDFKit, one section per page (carrying pageRange).
+//  PDFKit is unavailable on tvOS/watchOS, so the whole converter is gated on
+//  `canImport(PDFKit)` (the registry skips it where it can't compile).
+//
+
+#if canImport(PDFKit)
+import Foundation
+import PDFKit
+
+public struct PDFConverter: DocumentConverter {
+
+    public init() {}
+
+    public func accepts(_ info: StreamInfo) -> Bool {
+        info.detectedFormat == .pdf
+    }
+
+    public func convert(_ data: Data, info: StreamInfo) async throws -> ConverterResult {
+        guard let document = PDFDocument(data: data) else {
+            throw PicoDocsError.fileCorrupted
+        }
+
+        var sections: [DocumentSection] = []
+        for index in 0..<document.pageCount {
+            try Task.checkCancellation()
+            guard let page = document.page(at: index) else { continue }
+            let text = (page.string ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { continue }
+            let pageNumber = index + 1
+            sections.append(DocumentSection(
+                kind: .body,
+                markdown: text,
+                pageRange: pageNumber...pageNumber
+            ))
+        }
+
+        guard !sections.isEmpty else { throw PicoDocsError.emptyDocument }
+
+        let title = document.documentAttributes?[PDFDocumentAttribute.titleAttribute] as? String
+        return ConverterResult(
+            title: (title?.isEmpty == false) ? title : info.filename,
+            sections: sections
+        )
+    }
+}
+#endif

--- a/Sources/PicoDocs/Converters/PDFConverter.swift
+++ b/Sources/PicoDocs/Converters/PDFConverter.swift
@@ -23,6 +23,10 @@ public struct PDFConverter: DocumentConverter {
         guard let document = PDFDocument(data: data) else {
             throw PicoDocsError.fileCorrupted
         }
+        // A password-protected PDF parses but stays locked; pages yield no text.
+        guard !document.isLocked else {
+            throw PicoDocsError.noAccess
+        }
 
         var sections: [DocumentSection] = []
         for index in 0..<document.pageCount {
@@ -40,9 +44,14 @@ public struct PDFConverter: DocumentConverter {
 
         guard !sections.isEmpty else { throw PicoDocsError.emptyDocument }
 
-        let title = document.documentAttributes?[PDFDocumentAttribute.titleAttribute] as? String
+        let attributes = document.documentAttributes
+        let title = (attributes?[PDFDocumentAttribute.titleAttribute] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let author = (attributes?[PDFDocumentAttribute.authorAttribute] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         return ConverterResult(
             title: (title?.isEmpty == false) ? title : info.filename,
+            author: (author?.isEmpty == false) ? author : nil,
             sections: sections
         )
     }


### PR DESCRIPTION
## Context

Rounds out the new engine's coverage of the common formats (PDF was already fine in the legacy flow, but the engine needs it before Phase 4 swaps `PicoDocument` onto `PicoDocsEngine`).

## What's here

- **`PDFConverter`** (PDFKit) — accepts `.pdf`, emits **one `.body` section per page** (carrying `pageRange`), with the document title from PDF metadata. Registered at specific priority.
- Gated on **`#if canImport(PDFKit)`** (PDFKit is absent on tvOS/watchOS); `makeDefault()` registers it only where it compiles — the platform-matrix guarding from the plan.

## Notes

- PDF text extraction is inherently plain text (no Markdown structure) — same as the old `PDFParser`, but now structured per-page with provenance.
- Page-level `Task.checkCancellation()`.

## Verification

- macOS CI (`swift build`, Swift 6) — PDFKit is available there, so the `#if` block compiles.

https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP)_