### PR TITLE
Phase 4c: pure-Swift Readability scorer (reader-mode HTML)

### DIFF
--- a/Sources/PicoDocs/Converters/HTML/HTMLConverter.swift
+++ b/Sources/PicoDocs/Converters/HTML/HTMLConverter.swift
@@ -4,10 +4,13 @@
 //
 //  Converts HTML to Markdown via the pure-Swift SwiftSoup walker. Replaces the
 //  old behavior where HTML was returned as raw markup (issue #2). Reader-mode
-//  cleanup (Readability) is a separate, optional pass added later.
+//  cleanup runs by default via `ReadabilityScorer` (keep the article, drop
+//  nav/ads/boilerplate); set `StreamInfo.enhanceReadability = false` to convert
+//  the full body verbatim.
 //
 
 import Foundation
+import SwiftSoup
 
 public struct HTMLConverter: DocumentConverter {
 
@@ -26,14 +29,36 @@ public struct HTMLConverter: DocumentConverter {
         guard let html = decoded else {
             throw ConverterError.decodingFailed
         }
+        let baseURI = info.url?.absoluteString ?? ""
 
-        let (title, markdown) = try HTMLToMarkdown.convert(html: html, baseURI: info.url?.absoluteString)
+        // Reader-mode extraction (default on): keep the main article, drop
+        // nav/ads/boilerplate. The scorer mutates the DOM it walks, so it gets
+        // its own parse; a confident hit returns immediately, otherwise we fall
+        // through to converting the full document body (no regression).
+        if info.enhanceReadability,
+           let scored = try? SwiftSoup.parse(html, baseURI),
+           let result = ReadabilityScorer.parse(scored) {
+            let markdown = HTMLToMarkdown.convert(element: result.article)
+            if !markdown.isEmpty {
+                let title = result.readable.title.isEmpty
+                    ? (try? scored.title()).flatMap { $0.isEmpty ? nil : $0 }
+                    : result.readable.title
+                let section = DocumentSection(title: title, kind: .body, markdown: markdown)
+                return ConverterResult(title: title, author: result.readable.byline, sections: [section])
+            }
+        }
+
+        // Full-document fallback (Readability disabled, or no confident article).
+        let document = try SwiftSoup.parse(html, baseURI)
+        let documentTitle = (try? document.title()).flatMap { $0.isEmpty ? nil : $0 }
+        let body = document.body() ?? document
+        let markdown = HTMLToMarkdown.convert(element: body)
         guard !markdown.isEmpty else {
             throw PicoDocsError.emptyDocument
         }
 
-        let section = DocumentSection(title: title, kind: .body, markdown: markdown)
-        return ConverterResult(title: title, sections: [section])
+        let section = DocumentSection(title: documentTitle, kind: .body, markdown: markdown)
+        return ConverterResult(title: documentTitle, sections: [section])
     }
 
     /// Sniffs a document-declared charset (`<meta charset="...">` or

--- a/Sources/PicoDocs/Converters/HTML/HTMLToMarkdown.swift
+++ b/Sources/PicoDocs/Converters/HTML/HTMLToMarkdown.swift
@@ -24,6 +24,16 @@ enum HTMLToMarkdown {
         return (title, markdown)
     }
 
+    /// Renders an already-parsed `Element` (e.g. the body, or the subtree the
+    /// Readability scorer selected) to Markdown. Relative links resolve against
+    /// the element's owner-document base URI. `Document` is an `Element`, so the
+    /// whole document can be passed too.
+    static func convert(element: Element) -> String {
+        var out = ""
+        renderChildren(of: element, into: &out)
+        return normalizeBlankLines(out).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     // MARK: - Walking
 
     private static func renderChildren(of node: Node, into out: inout String, preserveWhitespace: Bool = false) {

--- a/Sources/PicoDocs/Converters/HTML/HTMLToMarkdown.swift
+++ b/Sources/PicoDocs/Converters/HTML/HTMLToMarkdown.swift
@@ -28,9 +28,13 @@ enum HTMLToMarkdown {
     /// Readability scorer selected) to Markdown. Relative links resolve against
     /// the element's owner-document base URI. `Document` is an `Element`, so the
     /// whole document can be passed too.
+    ///
+    /// Renders the element *itself*, not just its children, so a semantic root
+    /// (e.g. a `<table>` chosen as the Readability top candidate) goes through
+    /// the matching block handler rather than having its cells concatenated.
     static func convert(element: Element) -> String {
         var out = ""
-        renderChildren(of: element, into: &out)
+        render(element, into: &out)
         return normalizeBlankLines(out).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 

--- a/Sources/PicoDocs/Converters/HTML/ReadabilityScorer.swift
+++ b/Sources/PicoDocs/Converters/HTML/ReadabilityScorer.swift
@@ -114,6 +114,7 @@ enum ReadabilityScorer {
         "skyscraper", "social", "sponsor", "supplemental", "ad-break", "agegate",
         "pagination", "pager", "popup", "yom-remote", "nav", "masthead", "modal",
         "cookie", "complementary", "contentinfo", "dialog", "share",
+        "newsletter", "promo", "subscribe", "signup", "sign-up", "paywall",
     ]
 
     /// Substrings that keep a node even if it also matched `unlikely`.
@@ -224,28 +225,72 @@ enum ReadabilityScorer {
 
     // MARK: - Sibling aggregation
 
+    /// Table-structure tags whose Markdown only renders correctly from the
+    /// enclosing `<table>` (HTMLToMarkdown only has a `table` handler).
+    private static let tableSectionTags: Set<String> = [
+        "td", "th", "tr", "tbody", "thead", "tfoot", "caption", "col", "colgroup",
+    ]
+
     /// Assembles the final article subtree. Readability merges the top candidate
     /// with its qualifying siblings; to preserve reading order we keep them in
-    /// place and instead prune only the *non*-qualifying siblings from the shared
-    /// parent, returning that parent. Because nothing is moved, original DOM order
-    /// and per-node base URIs (link resolution) are preserved — the same ordered
-    /// set as Readability's "wrap siblings in a new container", without allocating
-    /// a node or relying on element-construction APIs.
+    /// place and prune the rest. Because nothing is moved, original DOM order and
+    /// per-node base URIs (link resolution) are preserved — the same ordered set
+    /// as Readability's "wrap siblings in a new container", without allocating a
+    /// node or relying on element-construction APIs.
     private static func assembleArticle(_ topCandidate: Element, topScore: Double, scores: [ObjectIdentifier: Double]) -> Element {
-        // For a body-level candidate there are no meaningful siblings to merge
-        // (its only sibling would be <head>); return it directly.
-        guard topCandidate.tagName().lowercased() != "body", let parent = topCandidate.parent() else {
-            return topCandidate
+        // A candidate inside a table renders correctly only from the <table>
+        // (otherwise the cells are concatenated instead of forming a table).
+        let candidate = enclosingTable(of: topCandidate) ?? topCandidate
+
+        // Choose the root to filter and the child to always keep (the anchor):
+        //  - a normal candidate: filter its parent's children, keep the candidate;
+        //  - a body-level candidate (flat layout where <body> itself wins): filter
+        //    <body>'s own children so promo/newsletter blocks don't leak.
+        let root: Element
+        let anchor: Element?
+        if candidate.tagName().lowercased() == "body" || candidate.parent() == nil {
+            root = candidate
+            anchor = nil
+        } else if let parent = candidate.parent() {
+            root = parent
+            anchor = candidate
+        } else {
+            return candidate
         }
+
         let threshold = max(10.0, topScore * 0.2)
 
-        for sibling in parent.children().array() {
-            if sibling === topCandidate { continue }
-            if !siblingQualifies(sibling, threshold: threshold, scores: scores) {
-                try? sibling.remove()
+        // Prune at the node level: drop non-qualifying element children and loose
+        // non-blank text nodes (HTMLToMarkdown renders text nodes directly, so a
+        // bare "Advertisement" string between blocks would otherwise leak). The
+        // anchor and qualifying element siblings stay in their original order.
+        for child in root.getChildNodes() {
+            if let element = child as? Element {
+                if element === anchor { continue }
+                if !siblingQualifies(element, threshold: threshold, scores: scores) {
+                    try? element.remove()
+                }
+            } else if let textNode = child as? TextNode {
+                if !textNode.getWholeText().trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    try? textNode.remove()
+                }
             }
         }
-        return parent
+        return root
+    }
+
+    /// Returns the `<table>` enclosing a table-structure element (or the element
+    /// itself if it is a `<table>`); `nil` for non-table elements.
+    private static func enclosingTable(of element: Element) -> Element? {
+        let tag = element.tagName().lowercased()
+        if tag == "table" { return element }
+        guard tableSectionTags.contains(tag) else { return nil }
+        var current = element.parent()
+        while let node = current {
+            if node.tagName().lowercased() == "table" { return node }
+            current = node.parent()
+        }
+        return nil
     }
 
     /// Whether a sibling of the top candidate looks like article content worth

--- a/Sources/PicoDocs/Converters/HTML/ReadabilityScorer.swift
+++ b/Sources/PicoDocs/Converters/HTML/ReadabilityScorer.swift
@@ -66,19 +66,19 @@ enum ReadabilityScorer {
         }
 
         // Scale each candidate by (1 - link density) and pick the best.
-        var topCandidate: Element?
+        var bestCandidate: Element?
         var topScore = -Double.greatestFiniteMagnitude
         for (key, element) in candidates {
             let scaled = (scores[key] ?? 0) * (1 - linkDensity(element))
             scores[key] = scaled
             if scaled > topScore {
                 topScore = scaled
-                topCandidate = element
+                bestCandidate = element
             }
         }
-        guard let article = topCandidate else { return nil }
+        guard let topCandidate = bestCandidate else { return nil }
 
-        appendQualifyingSiblings(to: article, topScore: topScore, scores: scores)
+        let article = assembleArticle(topCandidate, topScore: topScore, scores: scores)
 
         let articleText = text(article)
         guard articleText.count >= minArticleTextLength else { return nil }
@@ -121,21 +121,29 @@ enum ReadabilityScorer {
         "and", "article", "body", "column", "content", "main", "shadow",
     ]
 
-    private static func stripUnlikelyNodes(in body: Element) {
-        for element in descendants(of: body) {
-            let tag = element.tagName().lowercased()
-            if tag == "body" || tag == "a" { continue }
-            if stripTags.contains(tag) {
-                try? element.remove()
-                continue
+    /// Recursively removes never-content tags and unlikely-candidate nodes,
+    /// pruning whole subtrees in place. We never recurse into a node we remove,
+    /// so discarded subtrees aren't processed (cheaper than flattening the whole
+    /// tree first, then revisiting children of already-removed ancestors).
+    private static func stripUnlikelyNodes(in element: Element) {
+        for child in element.children().array() {
+            let tag = child.tagName().lowercased()
+            // Never strip anchors themselves, but still descend into kept nodes.
+            if tag != "a" {
+                if stripTags.contains(tag) {
+                    try? child.remove()
+                    continue
+                }
+                let signature = (attr(child, "class") + " " + attr(child, "id") + " " + attr(child, "role"))
+                    .lowercased()
+                if !signature.isEmpty,
+                   unlikely.contains(where: { signature.contains($0) }),
+                   !maybe.contains(where: { signature.contains($0) }) {
+                    try? child.remove()
+                    continue
+                }
             }
-            let signature = (attr(element, "class") + " " + attr(element, "id") + " " + attr(element, "role"))
-                .lowercased()
-            guard !signature.isEmpty else { continue }
-            if unlikely.contains(where: { signature.contains($0) }),
-               !maybe.contains(where: { signature.contains($0) }) {
-                try? element.remove()
-            }
+            stripUnlikelyNodes(in: child)
         }
     }
 
@@ -216,35 +224,45 @@ enum ReadabilityScorer {
 
     // MARK: - Sibling aggregation
 
-    /// Pull in sibling nodes that also look like content (Readability merges the
-    /// top candidate's qualifying siblings into the article).
-    private static func appendQualifyingSiblings(to article: Element, topScore: Double, scores: [ObjectIdentifier: Double]) {
-        guard let parent = article.parent() else { return }
+    /// Assembles the final article subtree. Readability merges the top candidate
+    /// with its qualifying siblings; to preserve reading order we keep them in
+    /// place and instead prune only the *non*-qualifying siblings from the shared
+    /// parent, returning that parent. Because nothing is moved, original DOM order
+    /// and per-node base URIs (link resolution) are preserved — the same ordered
+    /// set as Readability's "wrap siblings in a new container", without allocating
+    /// a node or relying on element-construction APIs.
+    private static func assembleArticle(_ topCandidate: Element, topScore: Double, scores: [ObjectIdentifier: Double]) -> Element {
+        // For a body-level candidate there are no meaningful siblings to merge
+        // (its only sibling would be <head>); return it directly.
+        guard topCandidate.tagName().lowercased() != "body", let parent = topCandidate.parent() else {
+            return topCandidate
+        }
         let threshold = max(10.0, topScore * 0.2)
 
         for sibling in parent.children().array() {
-            if sibling === article { continue }
-
-            var qualifies = false
-            if let siblingScore = scores[ObjectIdentifier(sibling)], siblingScore >= threshold {
-                qualifies = true
-            } else if sibling.tagName().lowercased() == "p" {
-                let siblingText = text(sibling)
-                let density = linkDensity(sibling)
-                if siblingText.count > 80, density < 0.25 {
-                    qualifies = true
-                } else if siblingText.count > 0, density == 0,
-                          siblingText.range(of: #"\.( |$)"#, options: .regularExpression) != nil {
-                    qualifies = true
-                }
-            }
-
-            if qualifies {
-                // Moves `sibling` under `article`; safe because we iterate a
-                // snapshot array, and the owner document (base URI) is unchanged.
-                _ = try? article.appendChild(sibling)
+            if sibling === topCandidate { continue }
+            if !siblingQualifies(sibling, threshold: threshold, scores: scores) {
+                try? sibling.remove()
             }
         }
+        return parent
+    }
+
+    /// Whether a sibling of the top candidate looks like article content worth
+    /// keeping (mirrors Readability's sibling-merge test).
+    private static func siblingQualifies(_ sibling: Element, threshold: Double, scores: [ObjectIdentifier: Double]) -> Bool {
+        if let siblingScore = scores[ObjectIdentifier(sibling)], siblingScore >= threshold {
+            return true
+        }
+        guard sibling.tagName().lowercased() == "p" else { return false }
+        let siblingText = text(sibling)
+        let density = linkDensity(sibling)
+        if siblingText.count > 80, density < 0.25 { return true }
+        if siblingText.count > 0, density == 0,
+           siblingText.range(of: #"\.( |$)"#, options: .regularExpression) != nil {
+            return true
+        }
+        return false
     }
 
     // MARK: - Metadata

--- a/Sources/PicoDocs/Converters/HTML/ReadabilityScorer.swift
+++ b/Sources/PicoDocs/Converters/HTML/ReadabilityScorer.swift
@@ -117,9 +117,13 @@ enum ReadabilityScorer {
         "newsletter", "promo", "subscribe", "signup", "sign-up", "paywall",
     ]
 
-    /// Substrings that keep a node even if it also matched `unlikely`.
+    /// Substrings that keep a node even if it also matched `unlikely`. Includes
+    /// the positive article signals (`post`/`entry`/`hentry`) so common article
+    /// header/lead wrappers like `entry-header` or `post-header` survive (they
+    /// match `unlikely` via "header" but carry the visible title/byline/lead).
     private static let maybe: [String] = [
         "and", "article", "body", "column", "content", "main", "shadow",
+        "post", "entry", "hentry", "h-entry",
     ]
 
     /// Recursively removes never-content tags and unlikely-candidate nodes,
@@ -293,26 +297,26 @@ enum ReadabilityScorer {
         return nil
     }
 
-    /// Tags that carry article structure/content on their own, even without a
-    /// score — so pruning around the top candidate (especially when `<body>`
-    /// wins a flat layout) keeps headings, lists, tables, quotes and figures
-    /// rather than dropping them and losing structure.
-    private static let structuralContentTags: Set<String> = [
-        "h1", "h2", "h3", "h4", "h5", "h6", "p", "ul", "ol", "dl", "blockquote",
-        "pre", "table", "figure", "figcaption", "article", "section", "main",
-        "header", "hr",
+    /// Tags safe to preserve unconditionally during pruning: headings and rules
+    /// are short and structural with no boilerplate risk — unlike `<ul>`/
+    /// `<section>`/`<table>`/`<header>` wrappers, which may be navigation or
+    /// related-link blocks and so must still pass the link-density check.
+    private static let unconditionalKeepTags: Set<String> = [
+        "h1", "h2", "h3", "h4", "h5", "h6", "hr",
     ]
 
     /// Whether an element should be kept when assembling the article (the top
     /// candidate's qualifying siblings, or — when `<body>` itself wins — body's
-    /// own children). Keeps scored candidates, article-structure tags, and any
-    /// text-bearing block (e.g. a leaf `<div>`/`<pre>`) with low link density;
-    /// drops residual navigation/boilerplate (high link density) and empties.
+    /// own children). Headings/rules are always kept and a strongly-scored
+    /// candidate is kept; everything else — including structural tags like
+    /// `<ul>`/`<section>`/`<table>`/`<header>` — must read like content (real
+    /// text, low link density), so navigation and related-link blocks are dropped
+    /// rather than kept by tag alone.
     private static func keepAsArticleContent(_ element: Element, threshold: Double, scores: [ObjectIdentifier: Double]) -> Bool {
-        if let score = scores[ObjectIdentifier(element)], score >= threshold {
+        if unconditionalKeepTags.contains(element.tagName().lowercased()) {
             return true
         }
-        if structuralContentTags.contains(element.tagName().lowercased()) {
+        if let score = scores[ObjectIdentifier(element)], score >= threshold {
             return true
         }
         let elementText = text(element)

--- a/Sources/PicoDocs/Converters/HTML/ReadabilityScorer.swift
+++ b/Sources/PicoDocs/Converters/HTML/ReadabilityScorer.swift
@@ -1,0 +1,321 @@
+//
+//  ReadabilityScorer.swift
+//  PicoDocs
+//
+//  A pure-Swift, dependency-free port of the core of Mozilla's Readability
+//  `grabArticle` scoring, run over a SwiftSoup DOM. This replaces the deleted
+//  WKWebView + bundled Readability.js path: it needs no JavaScript engine and no
+//  main-thread hop, so it runs off-actor like the rest of the engine.
+//
+//  It is intentionally a *subset* of Readability.js — strip unlikely nodes,
+//  score paragraphs by text/comma/class signals, propagate to ancestors, pick a
+//  top candidate, then pull in qualifying siblings. When it can't find a
+//  confident article it returns `nil`, and `HTMLConverter` falls back to
+//  converting the whole document body (i.e. no regression versus skipping it).
+//
+
+import Foundation
+import SwiftSoup
+
+enum ReadabilityScorer {
+
+    /// The extracted article: the DOM subtree to render (kept attached to its
+    /// owner document so relative links still resolve) plus a `Readable` value
+    /// carrying the title/byline/excerpt/site metadata.
+    struct Result {
+        let article: Element
+        let readable: Readable
+    }
+
+    /// Minimum extracted text length to trust the result. Below this we return
+    /// `nil` so the caller converts the full body instead of a tiny fragment.
+    private static let minArticleTextLength = 140
+
+    /// Best-effort extraction. Never throws: any SwiftSoup error degrades to
+    /// `nil` (caller falls back to full-body conversion).
+    static func parse(_ document: Document) -> Result? {
+        guard let body = document.body() else { return nil }
+
+        let meta = metadata(document)
+        stripUnlikelyNodes(in: body)
+
+        // Score the candidate paragraphs and propagate to their ancestors.
+        var scores: [ObjectIdentifier: Double] = [:]
+        var candidates: [ObjectIdentifier: Element] = [:]
+
+        for paragraph in scoreableNodes(in: body) {
+            let innerText = text(paragraph)
+            guard innerText.count >= 25 else { continue }
+
+            let ancestors = ancestorChain(paragraph, max: 3)
+            guard !ancestors.isEmpty else { continue }
+
+            var contentScore = 1.0
+            contentScore += Double(innerText.filter { $0 == "," }.count)
+            contentScore += Double(min(innerText.count / 100, 3))
+
+            for (level, ancestor) in ancestors.enumerated() {
+                let key = ObjectIdentifier(ancestor)
+                if scores[key] == nil {
+                    scores[key] = baseScore(ancestor)
+                    candidates[key] = ancestor
+                }
+                let divider: Double = level == 0 ? 1 : (level == 1 ? 2 : Double(level) * 3)
+                scores[key, default: 0] += contentScore / divider
+            }
+        }
+
+        // Scale each candidate by (1 - link density) and pick the best.
+        var topCandidate: Element?
+        var topScore = -Double.greatestFiniteMagnitude
+        for (key, element) in candidates {
+            let scaled = (scores[key] ?? 0) * (1 - linkDensity(element))
+            scores[key] = scaled
+            if scaled > topScore {
+                topScore = scaled
+                topCandidate = element
+            }
+        }
+        guard let article = topCandidate else { return nil }
+
+        appendQualifyingSiblings(to: article, topScore: topScore, scores: scores)
+
+        let articleText = text(article)
+        guard articleText.count >= minArticleTextLength else { return nil }
+
+        let html = (try? article.outerHtml()) ?? ""
+        let readable = Readable(
+            title: meta.title ?? "",
+            content: html,
+            textContent: articleText,
+            length: articleText.count,
+            excerpt: meta.excerpt,
+            byline: meta.byline,
+            dir: nil,
+            siteName: meta.siteName,
+            lang: meta.lang
+        )
+        return Result(article: article, readable: readable)
+    }
+
+    // MARK: - Stripping
+
+    /// Tags that are never article content.
+    private static let stripTags: Set<String> = [
+        "script", "style", "noscript", "nav", "aside", "form",
+        "button", "input", "select", "textarea", "iframe", "svg", "object", "embed",
+    ]
+
+    /// class/id/role substrings that mark a node as unlikely to be content.
+    private static let unlikely: [String] = [
+        "-ad-", "ai2html", "banner", "breadcrumb", "combx", "comment", "community",
+        "cover-wrap", "disqus", "extra", "footer", "gdpr", "header", "legends", "menu",
+        "menubar", "related", "remark", "replies", "rss", "shoutbox", "sidebar",
+        "skyscraper", "social", "sponsor", "supplemental", "ad-break", "agegate",
+        "pagination", "pager", "popup", "yom-remote", "nav", "masthead", "modal",
+        "cookie", "complementary", "contentinfo", "dialog", "share",
+    ]
+
+    /// Substrings that keep a node even if it also matched `unlikely`.
+    private static let maybe: [String] = [
+        "and", "article", "body", "column", "content", "main", "shadow",
+    ]
+
+    private static func stripUnlikelyNodes(in body: Element) {
+        for element in descendants(of: body) {
+            let tag = element.tagName().lowercased()
+            if tag == "body" || tag == "a" { continue }
+            if stripTags.contains(tag) {
+                try? element.remove()
+                continue
+            }
+            let signature = (attr(element, "class") + " " + attr(element, "id") + " " + attr(element, "role"))
+                .lowercased()
+            guard !signature.isEmpty else { continue }
+            if unlikely.contains(where: { signature.contains($0) }),
+               !maybe.contains(where: { signature.contains($0) }) {
+                try? element.remove()
+            }
+        }
+    }
+
+    // MARK: - Candidate collection & scoring
+
+    /// Block-level tags whose presence means a `<div>` is a wrapper, not a leaf
+    /// paragraph.
+    private static let blockTags: Set<String> = [
+        "div", "p", "section", "article", "ul", "ol", "dl", "table", "pre",
+        "blockquote", "figure", "header", "footer", "aside", "nav",
+        "h1", "h2", "h3", "h4", "h5", "h6",
+    ]
+
+    /// Nodes whose text contributes to scoring: paragraphs, table cells, preformatted
+    /// blocks, and "leaf" divs (divs with no block-level children, i.e. text wrappers).
+    private static func scoreableNodes(in body: Element) -> [Element] {
+        descendants(of: body).filter { element in
+            switch element.tagName().lowercased() {
+            case "p", "td", "pre":
+                return true
+            case "div":
+                return !element.children().array().contains { blockTags.contains($0.tagName().lowercased()) }
+            default:
+                return false
+            }
+        }
+    }
+
+    /// Per-tag starting score (mirrors Readability's `initializeNode`).
+    private static func baseScore(_ element: Element) -> Double {
+        var score: Double
+        switch element.tagName().lowercased() {
+        case "div":
+            score = 5
+        case "pre", "td", "blockquote":
+            score = 3
+        case "address", "ol", "ul", "dl", "dd", "dt", "li", "form":
+            score = -3
+        case "h1", "h2", "h3", "h4", "h5", "h6", "th":
+            score = -5
+        default:
+            score = 0
+        }
+        return score + classWeight(element)
+    }
+
+    /// +/- weight from positive/negative class & id signals.
+    private static func classWeight(_ element: Element) -> Double {
+        let signature = (attr(element, "class") + " " + attr(element, "id")).lowercased()
+        var weight = 0.0
+        if negative.contains(where: { signature.contains($0) }) { weight -= 25 }
+        if positive.contains(where: { signature.contains($0) }) { weight += 25 }
+        return weight
+    }
+
+    private static let positive: [String] = [
+        "article", "body", "content", "entry", "hentry", "h-entry", "main", "page",
+        "pagination", "post", "text", "blog", "story", "column",
+    ]
+
+    private static let negative: [String] = [
+        "hidden", "banner", "combx", "comment", "com-", "contact", "foot", "footer",
+        "footnote", "gdpr", "masthead", "media", "meta", "outbrain", "promo", "related",
+        "scroll", "share", "shoutbox", "sidebar", "skyscraper", "sponsor", "shopping",
+        "tags", "widget", "social", "modal", "popup",
+    ]
+
+    /// Ratio of link text to total text — high means navigation/boilerplate.
+    private static func linkDensity(_ element: Element) -> Double {
+        let total = Double(text(element).count)
+        guard total > 0 else { return 0 }
+        var linkLength = 0
+        for anchor in (try? element.getElementsByTag("a").array()) ?? [] {
+            linkLength += text(anchor).count
+        }
+        return Double(linkLength) / total
+    }
+
+    // MARK: - Sibling aggregation
+
+    /// Pull in sibling nodes that also look like content (Readability merges the
+    /// top candidate's qualifying siblings into the article).
+    private static func appendQualifyingSiblings(to article: Element, topScore: Double, scores: [ObjectIdentifier: Double]) {
+        guard let parent = article.parent() else { return }
+        let threshold = max(10.0, topScore * 0.2)
+
+        for sibling in parent.children().array() {
+            if sibling === article { continue }
+
+            var qualifies = false
+            if let siblingScore = scores[ObjectIdentifier(sibling)], siblingScore >= threshold {
+                qualifies = true
+            } else if sibling.tagName().lowercased() == "p" {
+                let siblingText = text(sibling)
+                let density = linkDensity(sibling)
+                if siblingText.count > 80, density < 0.25 {
+                    qualifies = true
+                } else if siblingText.count > 0, density == 0,
+                          siblingText.range(of: #"\.( |$)"#, options: .regularExpression) != nil {
+                    qualifies = true
+                }
+            }
+
+            if qualifies {
+                // Moves `sibling` under `article`; safe because we iterate a
+                // snapshot array, and the owner document (base URI) is unchanged.
+                _ = try? article.appendChild(sibling)
+            }
+        }
+    }
+
+    // MARK: - Metadata
+
+    private static func metadata(_ document: Document) -> (title: String?, byline: String?, excerpt: String?, siteName: String?, lang: String?) {
+        var properties: [String: String] = [:]   // <meta property=...>
+        var names: [String: String] = [:]         // <meta name=...> / itemprop
+
+        for meta in (try? document.getElementsByTag("meta").array()) ?? [] {
+            let content = attr(meta, "content")
+            guard !content.isEmpty else { continue }
+            let property = attr(meta, "property").lowercased()
+            if !property.isEmpty { properties[property] = content }
+            let name = attr(meta, "name").lowercased()
+            if !name.isEmpty { names[name] = content }
+            let itemprop = attr(meta, "itemprop").lowercased()
+            if !itemprop.isEmpty { names[itemprop] = content }
+        }
+
+        func clean(_ value: String?) -> String? {
+            guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+                return nil
+            }
+            return trimmed
+        }
+
+        let title = clean(properties["og:title"]) ?? clean(names["twitter:title"]) ?? clean(try? document.title())
+        let byline = clean(names["author"]) ?? clean(properties["article:author"]) ?? clean(names["dc.creator"])
+        let excerpt = clean(names["description"]) ?? clean(properties["og:description"])
+        let siteName = clean(properties["og:site_name"])
+
+        var lang: String?
+        if let htmlElement = try? document.getElementsByTag("html").first() {
+            lang = clean(try? htmlElement.attr("lang"))
+        }
+
+        return (title, byline, excerpt, siteName, lang)
+    }
+
+    // MARK: - SwiftSoup helpers
+
+    /// All descendant elements of `root`, depth-first (snapshot, so callers can
+    /// mutate the tree while iterating).
+    private static func descendants(of root: Element) -> [Element] {
+        var result: [Element] = []
+        func walk(_ element: Element) {
+            for child in element.children().array() {
+                result.append(child)
+                walk(child)
+            }
+        }
+        walk(root)
+        return result
+    }
+
+    /// Up to `max` ancestors, nearest first.
+    private static func ancestorChain(_ element: Element, max: Int) -> [Element] {
+        var chain: [Element] = []
+        var current = element.parent()
+        while let node = current, chain.count < max {
+            chain.append(node)
+            current = node.parent()
+        }
+        return chain
+    }
+
+    private static func text(_ element: Element) -> String {
+        (try? element.text()) ?? ""
+    }
+
+    private static func attr(_ element: Element, _ key: String) -> String {
+        (try? element.attr(key)) ?? ""
+    }
+}

--- a/Sources/PicoDocs/Converters/HTML/ReadabilityScorer.swift
+++ b/Sources/PicoDocs/Converters/HTML/ReadabilityScorer.swift
@@ -267,7 +267,7 @@ enum ReadabilityScorer {
         for child in root.getChildNodes() {
             if let element = child as? Element {
                 if element === anchor { continue }
-                if !siblingQualifies(element, threshold: threshold, scores: scores) {
+                if !keepAsArticleContent(element, threshold: threshold, scores: scores) {
                     try? element.remove()
                 }
             } else if let textNode = child as? TextNode {
@@ -293,21 +293,30 @@ enum ReadabilityScorer {
         return nil
     }
 
-    /// Whether a sibling of the top candidate looks like article content worth
-    /// keeping (mirrors Readability's sibling-merge test).
-    private static func siblingQualifies(_ sibling: Element, threshold: Double, scores: [ObjectIdentifier: Double]) -> Bool {
-        if let siblingScore = scores[ObjectIdentifier(sibling)], siblingScore >= threshold {
+    /// Tags that carry article structure/content on their own, even without a
+    /// score — so pruning around the top candidate (especially when `<body>`
+    /// wins a flat layout) keeps headings, lists, tables, quotes and figures
+    /// rather than dropping them and losing structure.
+    private static let structuralContentTags: Set<String> = [
+        "h1", "h2", "h3", "h4", "h5", "h6", "p", "ul", "ol", "dl", "blockquote",
+        "pre", "table", "figure", "figcaption", "article", "section", "main",
+        "header", "hr",
+    ]
+
+    /// Whether an element should be kept when assembling the article (the top
+    /// candidate's qualifying siblings, or — when `<body>` itself wins — body's
+    /// own children). Keeps scored candidates, article-structure tags, and any
+    /// text-bearing block (e.g. a leaf `<div>`/`<pre>`) with low link density;
+    /// drops residual navigation/boilerplate (high link density) and empties.
+    private static func keepAsArticleContent(_ element: Element, threshold: Double, scores: [ObjectIdentifier: Double]) -> Bool {
+        if let score = scores[ObjectIdentifier(element)], score >= threshold {
             return true
         }
-        guard sibling.tagName().lowercased() == "p" else { return false }
-        let siblingText = text(sibling)
-        let density = linkDensity(sibling)
-        if siblingText.count > 80, density < 0.25 { return true }
-        if siblingText.count > 0, density == 0,
-           siblingText.range(of: #"\.( |$)"#, options: .regularExpression) != nil {
+        if structuralContentTags.contains(element.tagName().lowercased()) {
             return true
         }
-        return false
+        let elementText = text(element)
+        return elementText.count >= 25 && linkDensity(element) < 0.5
     }
 
     // MARK: - Metadata

--- a/Sources/PicoDocs/Models/StreamInfo.swift
+++ b/Sources/PicoDocs/Models/StreamInfo.swift
@@ -58,6 +58,12 @@ public struct StreamInfo: Sendable, Equatable {
     /// extension/MIME-based guesses.
     public var confidence: Double
 
+    /// Whether HTML conversion should run the Readability extraction pass
+    /// (reader-mode: keep the main article, drop nav/ads/boilerplate). Defaults
+    /// to `true`; set `false` to convert the full document body verbatim.
+    /// Ignored by non-HTML converters.
+    public var enhanceReadability: Bool
+
     public init(
         filename: String? = nil,
         fileExtension: String? = nil,
@@ -66,7 +72,8 @@ public struct StreamInfo: Sendable, Equatable {
         url: URL? = nil,
         charset: String.Encoding? = nil,
         detectedFormat: DetectedFormat? = nil,
-        confidence: Double = 0
+        confidence: Double = 0,
+        enhanceReadability: Bool = true
     ) {
         self.filename = filename
         self.fileExtension = fileExtension
@@ -76,5 +83,6 @@ public struct StreamInfo: Sendable, Equatable {
         self.charset = charset
         self.detectedFormat = detectedFormat
         self.confidence = confidence
+        self.enhanceReadability = enhanceReadability
     }
 }

--- a/Sources/PicoDocs/PicoDocs.swift
+++ b/Sources/PicoDocs/PicoDocs.swift
@@ -28,9 +28,16 @@ public enum PicoDocsEngine {
         mimeType: String? = nil,
         url: URL? = nil,
         charset: String.Encoding? = nil,
+        enhanceReadability: Bool = true,
         registry: DocumentConverterRegistry = .default
     ) async throws -> ConverterResult {
-        let info = makeStreamInfo(filename: filename, mimeType: mimeType, url: url, charset: charset)
+        let info = makeStreamInfo(
+            filename: filename,
+            mimeType: mimeType,
+            url: url,
+            charset: charset,
+            enhanceReadability: enhanceReadability
+        )
         let resolved = ContentTypeDetector.classify(data, info: info)
         return try await registry.convert(data, info: resolved)
     }
@@ -43,6 +50,7 @@ public enum PicoDocsEngine {
         url: URL? = nil,
         charset: String.Encoding? = nil,
         to format: ExportFileType = .markdown,
+        enhanceReadability: Bool = true,
         registry: DocumentConverterRegistry = .default
     ) async throws -> String {
         let result = try await convert(
@@ -51,6 +59,7 @@ public enum PicoDocsEngine {
             mimeType: mimeType,
             url: url,
             charset: charset,
+            enhanceReadability: enhanceReadability,
             registry: registry
         )
         return try DocumentRenderer.render(result, to: format)
@@ -58,7 +67,7 @@ public enum PicoDocsEngine {
 
     // MARK: - StreamInfo construction
 
-    static func makeStreamInfo(filename: String?, mimeType: String?, url: URL?, charset: String.Encoding?) -> StreamInfo {
+    static func makeStreamInfo(filename: String?, mimeType: String?, url: URL?, charset: String.Encoding?, enhanceReadability: Bool = true) -> StreamInfo {
         let ext = fileExtension(filename: filename, url: url)
         // Use only the base type (before any ";" parameters) for UTType lookup.
         let baseMIME = mimeType?.split(separator: ";").first.map {
@@ -75,7 +84,8 @@ public enum PicoDocsEngine {
             mimeType: mimeType,
             utType: utType,
             url: url,
-            charset: charset ?? encoding(fromMIME: mimeType)
+            charset: charset ?? encoding(fromMIME: mimeType),
+            enhanceReadability: enhanceReadability
         )
     }
 

--- a/Sources/PicoDocs/PicoDocument+Fetch.swift
+++ b/Sources/PicoDocs/PicoDocument+Fetch.swift
@@ -49,7 +49,9 @@ extension PicoDocument {
     ///     Markdown sections (the canonical LLM form); multi-format rendering is a
     ///     follow-up.
     ///   - recursive: If true, parses child documents first.
-    ///   - enhanceReadability: Reserved for the optional Readability cleanup pass.
+    ///   - enhanceReadability: For HTML, run the Readability extraction pass
+    ///     (reader-mode: keep the main article, drop nav/ads/boilerplate). Ignored
+    ///     by non-HTML formats. Defaults to `true`.
     public nonisolated func parse(to type: ExportFileType? = nil, recursive: Bool = true, enhanceReadability: Bool = true) async throws {
         // Parse children first. A child failure is recorded on the child and is
         // not fatal to the parent.
@@ -76,7 +78,8 @@ extension PicoDocument {
             let result = try await PicoDocsEngine.convert(
                 data: originalContent,
                 filename: self.filename,
-                url: self.originURL
+                url: self.originURL,
+                enhanceReadability: enhanceReadability
             )
             let exported = try Self.exportedContent(from: result, format: type)
             await updateParsedDocument(result, content: exported)


### PR DESCRIPTION
## Phase 4c — Readability, pure-Swift

Restores reader-mode HTML cleanup (keep the main article, drop nav/ads/boilerplate) that the deleted WKWebView + `Readability.js` path used to provide — now with **no JavaScript engine and no main-thread hop**, so it runs off-actor like the rest of the engine.

### `ReadabilityScorer`
A dependency-free port of the core of Mozilla's Readability `grabArticle`, run over the SwiftSoup DOM:
- **Metadata** — `og:`/`twitter:`/`name` meta tags, `<title>`, `<html lang>`, captured into the retained `Readable` model.
- **Strip** — never-content tags (`script`/`style`/`nav`/`aside`/`form`/`iframe`/…) and nodes whose `class`/`id`/`role` match unlikely-candidate signals (kept if they also match `article`/`content`/`main`/…).
- **Score** — paragraphs (`p`/`td`/`pre` + leaf `div`s) by text length, comma count, and class/id weight, propagated to ancestors (parent ÷1, grandparent ÷2, …).
- **Select** — scale each candidate by `(1 − link density)`, take the top candidate, then merge in qualifying siblings.
- **Fallback** — below a minimum article length it returns `nil`, and the caller converts the full document body (so this is **never a regression** versus skipping Readability).

### Wiring
- `StreamInfo` gains `enhanceReadability` (default `true`), threaded through `PicoDocsEngine.convert`/`export` → `makeStreamInfo`, and from `PicoDocument.parse(enhanceReadability:)` (previously reserved/ignored).
- `HTMLConverter` runs the scorer by default (its own parse, since scoring mutates the DOM); a confident hit returns the extracted article + byline, otherwise it falls back to full-body. Pass `enhanceReadability: false` to convert the whole body verbatim.
- `HTMLToMarkdown` gains `convert(element:)` so the walker can render the chosen subtree; the existing `convert(html:)` stays (used by EPUB).

### Notes
- `+387 / −10`, all in the HTML path; other converters untouched.
- Reader-mode assertions (keep article body / drop nav+ads), ported from the old WebKit tests, land with the dedicated test PR that enables `swift test` in CI. CI here (`swift build`, macOS/Swift 6) compiles the new scorer.
- A JavaScriptCore higher-fidelity path remains an optional, opt-in follow-up (Phase 5); this pure-Swift scorer is the guaranteed default.

Part of the issue #2 greenfield rewrite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP)_