### PR TITLE
Phase 5a: pure-Swift RTFConverter

### DIFF
--- a/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
+++ b/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
@@ -54,14 +54,10 @@ public struct DocumentConverterRegistry: Sendable {
             .registering(SpreadsheetConverter(), priority: Priority.specific)
             .registering(EPUBConverter(), priority: Priority.specific)
             .registering(WordConverter(), priority: Priority.specific)
+            .registering(RTFConverter(), priority: Priority.specific)
         #if canImport(PDFKit)
         registry = registry.registering(PDFConverter(), priority: Priority.specific)
         #endif
-        // No RTFConverter is registered (intentional): the only prior RTF support
-        // was the legacy `NSAttributedString` path this rewrite removes (lossy,
-        // main-thread-only, macOS-biased). RTF therefore fails cleanly with
-        // `documentTypeNotSupported` rather than degrading silently; a dedicated
-        // pure-Swift RTF converter is a tracked follow-up.
         return registry.registering(PlainTextConverter(), priority: Priority.generic)
     }
 

--- a/Sources/PicoDocs/Converters/RTFConverter.swift
+++ b/Sources/PicoDocs/Converters/RTFConverter.swift
@@ -1,0 +1,190 @@
+//
+//  RTFConverter.swift
+//  PicoDocs
+//
+//  Converts RTF to Markdown with a small, dependency-free parser — no
+//  NSAttributedString (the lossy, main-thread-biased path this rewrite removed).
+//  It extracts text, paragraphs, and bold/italic emphasis, skips the control
+//  tables (font/color/stylesheet/info) and ignorable destinations, and decodes
+//  \uN / \'hh escapes. RTF carries no semantic headings, so none are inferred
+//  (we deliberately don't guess headings from font sizes).
+//
+
+import Foundation
+
+public struct RTFConverter: DocumentConverter {
+
+    public init() {}
+
+    public func accepts(_ info: StreamInfo) -> Bool {
+        info.detectedFormat == .rtf
+    }
+
+    public func convert(_ data: Data, info: StreamInfo) async throws -> ConverterResult {
+        // RTF is a byte-oriented ASCII container (non-ASCII arrives via \uN or
+        // \'hh escapes), so decode it losslessly as Latin-1.
+        guard let rtf = String(data: data, encoding: .isoLatin1), !rtf.isEmpty else {
+            throw ConverterError.decodingFailed
+        }
+        let markdown = Self.markdown(fromRTF: rtf)
+        guard !markdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw PicoDocsError.emptyDocument
+        }
+        let section = DocumentSection(title: info.filename, kind: .body, markdown: markdown)
+        return ConverterResult(title: info.filename, sections: [section])
+    }
+
+    // MARK: - Parser
+
+    private struct Run { var text: String; var bold: Bool; var italic: Bool }
+    private struct GroupState { var bold: Bool; var italic: Bool; var ignore: Bool }
+
+    /// Destination control words whose group contents are not body text.
+    private static let ignoredDestinations: Set<String> = [
+        "fonttbl", "colortbl", "stylesheet", "info", "pict", "header", "footer",
+        "headerl", "headerr", "headerf", "footerl", "footerr", "footerf",
+        "footnote", "object", "themedata", "colorschememapping", "latentstyles",
+        "datastore", "generator", "xmlnstbl", "listtable", "listoverridetable",
+        "revtbl", "rsidtbl",
+    ]
+
+    static func markdown(fromRTF rtf: String) -> String {
+        let chars = Array(rtf)
+        let n = chars.count
+        var i = 0
+
+        var bold = false
+        var italic = false
+        var ignore = false
+        var ucSkip = 1
+        var stack: [GroupState] = []
+
+        var runs: [Run] = []
+        var paragraphs: [String] = []
+
+        func appendText(_ s: String) {
+            guard !ignore, !s.isEmpty else { return }
+            if var last = runs.last, last.bold == bold, last.italic == italic {
+                last.text += s
+                runs[runs.count - 1] = last
+            } else {
+                runs.append(Run(text: s, bold: bold, italic: italic))
+            }
+        }
+
+        func flushParagraph() {
+            let rendered = runs.map { renderRun($0) }.joined()
+            runs.removeAll(keepingCapacity: true)
+            let trimmed = rendered.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { paragraphs.append(trimmed) }
+        }
+
+        while i < n {
+            let c = chars[i]
+            switch c {
+            case "{":
+                stack.append(GroupState(bold: bold, italic: italic, ignore: ignore))
+                i += 1
+
+            case "}":
+                if let saved = stack.popLast() {
+                    bold = saved.bold; italic = saved.italic; ignore = saved.ignore
+                }
+                i += 1
+
+            case "\\":
+                i += 1
+                guard i < n else { break }
+                let next = chars[i]
+                if next.isLetter {
+                    // Control word: letters, then an optional (signed) parameter,
+                    // then an optional single delimiting space.
+                    var word = ""
+                    while i < n, chars[i].isLetter { word.append(chars[i]); i += 1 }
+                    var paramText = ""
+                    if i < n, chars[i] == "-" { paramText.append("-"); i += 1 }
+                    while i < n, chars[i].isNumber { paramText.append(chars[i]); i += 1 }
+                    let param = Int(paramText)
+                    if i < n, chars[i] == " " { i += 1 }
+
+                    switch word {
+                    case "par", "row", "sect":
+                        flushParagraph()
+                    case "line":
+                        appendText("\n")
+                    case "tab", "cell":
+                        appendText("\t")
+                    case "plain":
+                        bold = false; italic = false
+                    case "b":
+                        bold = (param ?? 1) != 0
+                    case "i":
+                        italic = (param ?? 1) != 0
+                    case "uc":
+                        if let param { ucSkip = max(0, param) }
+                    case "u":
+                        if let param {
+                            let value = param < 0 ? param + 65_536 : param
+                            if value >= 0, let scalar = Unicode.Scalar(UInt32(value)) {
+                                appendText(String(Character(scalar)))
+                            }
+                        }
+                        // Skip the \ucN fallback characters that follow a \uN.
+                        var skipped = 0
+                        while i < n, skipped < ucSkip,
+                              chars[i] != "\\", chars[i] != "{", chars[i] != "}" {
+                            i += 1; skipped += 1
+                        }
+                    default:
+                        if Self.ignoredDestinations.contains(word) { ignore = true }
+                        // All other control words carry no body text.
+                    }
+                } else {
+                    // Control symbol.
+                    i += 1
+                    switch next {
+                    case "\\", "{", "}": appendText(String(next))
+                    case "~": appendText("\u{00A0}")          // non-breaking space
+                    case "_": appendText("-")                 // non-breaking hyphen
+                    case "-": break                            // optional hyphen
+                    case "*": ignore = true                    // ignorable destination
+                    case "'":
+                        if i + 1 < n,
+                           let byte = UInt32(String([chars[i], chars[i + 1]]), radix: 16),
+                           let scalar = Unicode.Scalar(byte) {
+                            appendText(String(Character(scalar)))
+                            i += 2
+                        }
+                    case "\n", "\r": flushParagraph()          // escaped newline = \par
+                    default: break
+                    }
+                }
+
+            case "\r", "\n":
+                i += 1                                          // raw newlines aren't content
+
+            default:
+                appendText(String(c))
+                i += 1
+            }
+        }
+        flushParagraph()
+        return paragraphs.joined(separator: "\n\n")
+    }
+
+    /// Renders one formatting run, keeping emphasis markers hugging the text (so
+    /// `**word** ` rather than `** word **`).
+    private static func renderRun(_ run: Run) -> String {
+        guard !run.text.isEmpty else { return "" }
+        if run.text.allSatisfy({ $0 == " " || $0 == "\t" || $0 == "\n" }) { return run.text }
+        let isSpace: (Character) -> Bool = { $0 == " " || $0 == "\t" }
+        let afterLeading = run.text.drop(while: isSpace)
+        let leading = String(run.text.prefix(run.text.count - afterLeading.count))
+        let trailingCount = afterLeading.reversed().prefix(while: isSpace).count
+        let trailing = String(afterLeading.suffix(trailingCount))
+        var core = String(afterLeading.dropLast(trailingCount))
+        if run.italic { core = "*\(core)*" }
+        if run.bold { core = "**\(core)**" }
+        return leading + core + trailing
+    }
+}

--- a/Sources/PicoDocs/Converters/RTFConverter.swift
+++ b/Sources/PicoDocs/Converters/RTFConverter.swift
@@ -117,10 +117,10 @@ public struct RTFConverter: DocumentConverter {
                     if i < n, chars[i] == " " { i += 1 }
 
                     switch word {
-                    case "par", "row", "sect":
+                    case "par", "row", "sect", "page":
                         if !ignore { flushParagraph() }   // a \par inside a skipped destination isn't a body break
                     case "line":
-                        appendText("\n")
+                        appendText("  \n")                // Markdown hard break (matches the DOCX w:br path)
                     case "tab", "cell":
                         appendText("\t")
                     case "emdash": appendText("\u{2014}")
@@ -236,6 +236,11 @@ public struct RTFConverter: DocumentConverter {
     /// (`\ansicpgN`, defaulting to Windows-1252 for `\ansi`) — so bytes 0x80–0x9F
     /// become the right punctuation/letters rather than C1 control characters.
     /// Falls back to Windows-1252, then Latin-1, for undecodable bytes.
+    ///
+    /// Each `\'hh` is decoded on its own. Multibyte ANSI code pages (e.g. 932
+    /// Shift-JIS) that split one character across consecutive `\'hh` escapes are
+    /// not reassembled here — a deliberately deferred legacy niche, since modern
+    /// RTF emits non-ASCII (including CJK) as `\uN`, which is handled in full.
     private static func decodeByte(_ byte: UInt8, encoding: String.Encoding) -> String {
         if let decoded = String(bytes: [byte], encoding: encoding), !decoded.isEmpty {
             return decoded

--- a/Sources/PicoDocs/Converters/RTFConverter.swift
+++ b/Sources/PicoDocs/Converters/RTFConverter.swift
@@ -26,6 +26,13 @@ public struct RTFConverter: DocumentConverter {
         guard let rtf = String(data: data, encoding: .isoLatin1), !rtf.isEmpty else {
             throw ConverterError.decodingFailed
         }
+        // A valid RTF document begins with the {\rtf signature. When .rtf was
+        // inferred from a filename/MIME hint rather than the magic bytes, reject
+        // mislabeled or corrupt input here (strict failure) instead of emitting
+        // its raw text as a "document".
+        guard rtf.drop(while: { $0.isWhitespace }).hasPrefix("{\\rtf") else {
+            throw PicoDocsError.fileCorrupted
+        }
         let markdown = Self.markdown(fromRTF: rtf)
         guard !markdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw PicoDocsError.emptyDocument
@@ -57,6 +64,7 @@ public struct RTFConverter: DocumentConverter {
         var italic = false
         var ignore = false
         var ucSkip = 1
+        var ansiEncoding: String.Encoding = .windowsCP1252
         var stack: [GroupState] = []
         var pendingHighSurrogate: Int?
 
@@ -115,6 +123,21 @@ public struct RTFConverter: DocumentConverter {
                         appendText("\n")
                     case "tab", "cell":
                         appendText("\t")
+                    case "emdash": appendText("\u{2014}")
+                    case "endash": appendText("\u{2013}")
+                    case "bullet": appendText("\u{2022}")
+                    case "lquote": appendText("\u{2018}")
+                    case "rquote": appendText("\u{2019}")
+                    case "ldblquote": appendText("\u{201C}")
+                    case "rdblquote": appendText("\u{201D}")
+                    case "emspace", "enspace", "qmspace": appendText(" ")
+                    case "ansicpg":
+                        if let param, let encoding = Self.encoding(forCodepage: param) { ansiEncoding = encoding }
+                    case "bin":
+                        // \binN: the next N bytes are raw binary (often inside an
+                        // ignored \pict/\object) and may contain { } or \ — skip
+                        // them so they can't corrupt group/brace parsing.
+                        if let param, param > 0 { i += min(param, n - i) }
                     case "plain":
                         bold = false; italic = false
                     case "b":
@@ -188,7 +211,7 @@ public struct RTFConverter: DocumentConverter {
                     case "*": ignore = true                    // ignorable destination
                     case "'":
                         if i + 1 < n, let byte = UInt8(String([chars[i], chars[i + 1]]), radix: 16) {
-                            appendText(Self.decodeANSIByte(byte))
+                            appendText(Self.decodeByte(byte, encoding: ansiEncoding))
                             i += 2
                         }
                     case "\n", "\r":
@@ -209,15 +232,27 @@ public struct RTFConverter: DocumentConverter {
         return paragraphs.joined(separator: "\n\n")
     }
 
-    /// Decodes a single `\'hh` byte using the Windows-1252 (ANSI) code page — the
-    /// near-universal default for `\ansi` RTF — so bytes 0x80–0x9F become smart
-    /// quotes/dashes rather than C1 control characters. Falls back to Latin-1 for
-    /// the few CP1252-undefined bytes.
-    private static func decodeANSIByte(_ byte: UInt8) -> String {
-        if let decoded = String(bytes: [byte], encoding: .windowsCP1252), !decoded.isEmpty {
+    /// Decodes a single `\'hh` byte using the document's declared code page
+    /// (`\ansicpgN`, defaulting to Windows-1252 for `\ansi`) — so bytes 0x80–0x9F
+    /// become the right punctuation/letters rather than C1 control characters.
+    /// Falls back to Windows-1252, then Latin-1, for undecodable bytes.
+    private static func decodeByte(_ byte: UInt8, encoding: String.Encoding) -> String {
+        if let decoded = String(bytes: [byte], encoding: encoding), !decoded.isEmpty {
+            return decoded
+        }
+        if encoding != .windowsCP1252,
+           let decoded = String(bytes: [byte], encoding: .windowsCP1252), !decoded.isEmpty {
             return decoded
         }
         return Unicode.Scalar(UInt32(byte)).map { String(Character($0)) } ?? ""
+    }
+
+    /// Maps an RTF `\ansicpgN` Windows code page number to a `String.Encoding`.
+    private static func encoding(forCodepage codepage: Int) -> String.Encoding? {
+        guard codepage > 0 else { return nil }
+        let cfEncoding = CFStringConvertWindowsCodepageToEncoding(UInt32(codepage))
+        guard cfEncoding != kCFStringEncodingInvalidId else { return nil }
+        return String.Encoding(rawValue: CFStringConvertEncodingToNSStringEncoding(cfEncoding))
     }
 
     /// Renders one formatting run, keeping emphasis markers hugging the text (so

--- a/Sources/PicoDocs/Converters/RTFConverter.swift
+++ b/Sources/PicoDocs/Converters/RTFConverter.swift
@@ -37,7 +37,7 @@ public struct RTFConverter: DocumentConverter {
     // MARK: - Parser
 
     private struct Run { var text: String; var bold: Bool; var italic: Bool }
-    private struct GroupState { var bold: Bool; var italic: Bool; var ignore: Bool }
+    private struct GroupState { var bold: Bool; var italic: Bool; var ignore: Bool; var ucSkip: Int }
 
     /// Destination control words whose group contents are not body text.
     private static let ignoredDestinations: Set<String> = [
@@ -58,6 +58,7 @@ public struct RTFConverter: DocumentConverter {
         var ignore = false
         var ucSkip = 1
         var stack: [GroupState] = []
+        var pendingHighSurrogate: Int?
 
         var runs: [Run] = []
         var paragraphs: [String] = []
@@ -83,12 +84,12 @@ public struct RTFConverter: DocumentConverter {
             let c = chars[i]
             switch c {
             case "{":
-                stack.append(GroupState(bold: bold, italic: italic, ignore: ignore))
+                stack.append(GroupState(bold: bold, italic: italic, ignore: ignore, ucSkip: ucSkip))
                 i += 1
 
             case "}":
                 if let saved = stack.popLast() {
-                    bold = saved.bold; italic = saved.italic; ignore = saved.ignore
+                    bold = saved.bold; italic = saved.italic; ignore = saved.ignore; ucSkip = saved.ucSkip
                 }
                 i += 1
 
@@ -109,7 +110,7 @@ public struct RTFConverter: DocumentConverter {
 
                     switch word {
                     case "par", "row", "sect":
-                        flushParagraph()
+                        if !ignore { flushParagraph() }   // a \par inside a skipped destination isn't a body break
                     case "line":
                         appendText("\n")
                     case "tab", "cell":
@@ -124,16 +125,53 @@ public struct RTFConverter: DocumentConverter {
                         if let param { ucSkip = max(0, param) }
                     case "u":
                         if let param {
+                            // \uN values are UTF-16 code units; combine surrogate
+                            // pairs so astral characters (e.g. emoji) survive.
                             let value = param < 0 ? param + 65_536 : param
-                            if value >= 0, let scalar = Unicode.Scalar(UInt32(value)) {
-                                appendText(String(Character(scalar)))
+                            if value >= 0xD800, value <= 0xDBFF {
+                                pendingHighSurrogate = value
+                            } else if value >= 0xDC00, value <= 0xDFFF {
+                                if let high = pendingHighSurrogate {
+                                    let combined = 0x10000 + (high - 0xD800) * 0x400 + (value - 0xDC00)
+                                    if let scalar = Unicode.Scalar(UInt32(combined)) {
+                                        appendText(String(Character(scalar)))
+                                    }
+                                    pendingHighSurrogate = nil
+                                }
+                                // a lone low surrogate is dropped
+                            } else {
+                                pendingHighSurrogate = nil
+                                if value >= 0, let scalar = Unicode.Scalar(UInt32(value)) {
+                                    appendText(String(Character(scalar)))
+                                }
                             }
                         }
-                        // Skip the \ucN fallback characters that follow a \uN.
+                        // Skip the \ucN fallback that follows a \uN. Each fallback
+                        // is one "unit", which may be a literal char, a \'hh hex
+                        // escape, a control word, or a control symbol — skip whole
+                        // units so an escaped fallback (e.g. a \'92 hex escape)
+                        // isn't re-parsed and duplicated into the output.
                         var skipped = 0
-                        while i < n, skipped < ucSkip,
-                              chars[i] != "\\", chars[i] != "{", chars[i] != "}" {
-                            i += 1; skipped += 1
+                        while i < n, skipped < ucSkip {
+                            let fallback = chars[i]
+                            if fallback == "{" || fallback == "}" {
+                                break
+                            } else if fallback == "\\" {
+                                if i + 1 < n, chars[i + 1] == "'" {
+                                    i += min(4, n - i)            // \ ' h h
+                                } else if i + 1 < n, chars[i + 1].isLetter {
+                                    i += 1
+                                    while i < n, chars[i].isLetter { i += 1 }
+                                    if i < n, chars[i] == "-" { i += 1 }
+                                    while i < n, chars[i].isNumber { i += 1 }
+                                    if i < n, chars[i] == " " { i += 1 }
+                                } else {
+                                    i += 2                         // control symbol
+                                }
+                            } else {
+                                i += 1
+                            }
+                            skipped += 1
                         }
                     default:
                         if Self.ignoredDestinations.contains(word) { ignore = true }
@@ -149,13 +187,12 @@ public struct RTFConverter: DocumentConverter {
                     case "-": break                            // optional hyphen
                     case "*": ignore = true                    // ignorable destination
                     case "'":
-                        if i + 1 < n,
-                           let byte = UInt32(String([chars[i], chars[i + 1]]), radix: 16),
-                           let scalar = Unicode.Scalar(byte) {
-                            appendText(String(Character(scalar)))
+                        if i + 1 < n, let byte = UInt8(String([chars[i], chars[i + 1]]), radix: 16) {
+                            appendText(Self.decodeANSIByte(byte))
                             i += 2
                         }
-                    case "\n", "\r": flushParagraph()          // escaped newline = \par
+                    case "\n", "\r":
+                        if !ignore { flushParagraph() }        // escaped newline = \par
                     default: break
                     }
                 }
@@ -170,6 +207,17 @@ public struct RTFConverter: DocumentConverter {
         }
         flushParagraph()
         return paragraphs.joined(separator: "\n\n")
+    }
+
+    /// Decodes a single `\'hh` byte using the Windows-1252 (ANSI) code page — the
+    /// near-universal default for `\ansi` RTF — so bytes 0x80–0x9F become smart
+    /// quotes/dashes rather than C1 control characters. Falls back to Latin-1 for
+    /// the few CP1252-undefined bytes.
+    private static func decodeANSIByte(_ byte: UInt8) -> String {
+        if let decoded = String(bytes: [byte], encoding: .windowsCP1252), !decoded.isEmpty {
+            return decoded
+        }
+        return Unicode.Scalar(UInt32(byte)).map { String(Character($0)) } ?? ""
     }
 
     /// Renders one formatting run, keeping emphasis markers hugging the text (so

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -49,6 +49,43 @@ struct ConverterTests {
         #expect(!md.contains("\\rtf"))
     }
 
+    @Test("RTF keeps a \\uN char and skips its \\'hh fallback (no duplicate)")
+    func rtfUnicodeFallback() async throws {
+        // A U+2019 right single quote written as the control word u8217, with a
+        // hex-escape CP1252 fallback, must yield one quote -- not the quote plus
+        // the raw fallback byte.
+        let rtf = "{\\rtf1\\ansi\\uc1 It\\u8217\\'92s fine.\\par}"
+        let md = try await PicoDocsEngine.convert(data: Data(rtf.utf8), filename: "q.rtf").markdown()
+        #expect(md.contains("It\u{2019}s fine."))
+        #expect(!md.contains("\u{0092}"))
+    }
+
+    @Test("RTF hex escapes decode via Windows-1252, not raw Latin-1")
+    func rtfWindows1252() async throws {
+        // 0x93/0x94 are CP1252 curly double quotes; 0x97 is an em dash. As raw
+        // Latin-1 these would be invisible C1 control characters.
+        let rtf = "{\\rtf1\\ansi \\'93quoted\\'94 and a dash\\'97here.\\par}"
+        let md = try await PicoDocsEngine.convert(data: Data(rtf.utf8), filename: "q.rtf").markdown()
+        #expect(md.contains("\u{201C}quoted\u{201D}"))
+        #expect(md.contains("\u{2014}"))
+    }
+
+    @Test("RTF combines \\uN surrogate pairs into astral characters")
+    func rtfSurrogatePair() async throws {
+        // U+1F600 as a UTF-16 surrogate pair (\uc0 means no fallback bytes).
+        let rtf = "{\\rtf1\\ansi\\uc0\\u-10179\\u-8704 done.\\par}"
+        let md = try await PicoDocsEngine.convert(data: Data(rtf.utf8), filename: "e.rtf").markdown()
+        #expect(md.contains("\u{1F600}"))
+        #expect(md.contains("done."))
+    }
+
+    @Test("RTF paragraph breaks inside skipped destinations don't split the body")
+    func rtfIgnoredDestinationParagraphs() async throws {
+        let rtf = "{\\rtf1\\ansi Hello{\\footnote\\par ignored}world.\\par}"
+        let md = try await PicoDocsEngine.convert(data: Data(rtf.utf8), filename: "f.rtf").markdown()
+        #expect(md.contains("Helloworld."))
+    }
+
     @Test("A corrupt DOCX throws instead of degrading to plain text")
     func corruptDocxIsStrict() async throws {
         // Detected as .docx by the filename hint, but the bytes aren't a zip — the

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -37,6 +37,18 @@ struct ConverterTests {
         #expect(result.title == "Sample EPUB")
     }
 
+    @Test("RTF converts to Markdown with paragraphs and emphasis")
+    func rtf() async throws {
+        let rtf = "{\\rtf1\\ansi\\deff0{\\fonttbl{\\f0 Times New Roman;}}Hello \\b world\\b0 . This is \\i italic\\i0  text.\\par Second paragraph here.\\par}"
+        let md = try await PicoDocsEngine.convert(data: Data(rtf.utf8), filename: "sample.rtf").markdown()
+        #expect(md.contains("**world**"))
+        #expect(md.contains("*italic*"))
+        #expect(md.contains("Second paragraph here."))
+        // Control tables are skipped, and no raw control words leak through.
+        #expect(!md.contains("Times New Roman"))
+        #expect(!md.contains("\\rtf"))
+    }
+
     @Test("A corrupt DOCX throws instead of degrading to plain text")
     func corruptDocxIsStrict() async throws {
         // Detected as .docx by the filename hint, but the bytes aren't a zip — the

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -111,6 +111,15 @@ struct ConverterTests {
         #expect(md.contains("\u{0430}\u{0431}"))
     }
 
+    @Test("RTF \\line is a hard break and \\page separates content")
+    func rtfLineAndPageBreaks() async throws {
+        let rtf = "{\\rtf1\\ansi Line one\\line Line two.\\page Next page.\\par}"
+        let md = try await PicoDocsEngine.convert(data: Data(rtf.utf8), filename: "l.rtf").markdown()
+        #expect(md.contains("Line one  \nLine two."))   // hard break preserved
+        #expect(md.contains("Next page."))
+        #expect(!md.contains("Line two.Next page."))     // \page kept them separate
+    }
+
     @Test("RTF \\binN binary payload doesn't corrupt brace parsing")
     func rtfBinaryPayload() async throws {
         // The byte after \bin1 is a '}' that must not close the \pict group.

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -86,6 +86,41 @@ struct ConverterTests {
         #expect(md.contains("Helloworld."))
     }
 
+    @Test("A mislabeled .rtf without the RTF header throws (strict failure)")
+    func rtfMislabeledThrows() async throws {
+        let notRTF = Data("this is not actually an RTF file".utf8)
+        await #expect(throws: (any Error).self) {
+            _ = try await PicoDocsEngine.convert(data: notRTF, filename: "notes.rtf")
+        }
+    }
+
+    @Test("RTF special-character control words become punctuation")
+    func rtfSpecialChars() async throws {
+        let rtf = "{\\rtf1\\ansi A\\emdash B, \\bullet item, \\ldblquote q\\rdblquote .\\par}"
+        let md = try await PicoDocsEngine.convert(data: Data(rtf.utf8), filename: "s.rtf").markdown()
+        #expect(md.contains("A\u{2014}B"))            // em dash
+        #expect(md.contains("\u{2022}"))              // bullet
+        #expect(md.contains("\u{201C}q\u{201D}"))     // curly double quotes
+    }
+
+    @Test("RTF honors a declared non-1252 code page for hex escapes")
+    func rtfCodePage1251() async throws {
+        // CP1251: 0xE0 -> U+0430, 0xE1 -> U+0431 (Cyrillic a/b).
+        let rtf = "{\\rtf1\\ansi\\ansicpg1251 \\'e0\\'e1 done.\\par}"
+        let md = try await PicoDocsEngine.convert(data: Data(rtf.utf8), filename: "c.rtf").markdown()
+        #expect(md.contains("\u{0430}\u{0431}"))
+    }
+
+    @Test("RTF \\binN binary payload doesn't corrupt brace parsing")
+    func rtfBinaryPayload() async throws {
+        // The byte after \bin1 is a '}' that must not close the \pict group.
+        let rtf = "{\\rtf1\\ansi Before {\\pict\\bin1 }X} After.\\par}"
+        let md = try await PicoDocsEngine.convert(data: Data(rtf.utf8), filename: "b.rtf").markdown()
+        #expect(md.contains("Before"))
+        #expect(md.contains("After."))
+        #expect(!md.contains("X"))
+    }
+
     @Test("A corrupt DOCX throws instead of degrading to plain text")
     func corruptDocxIsStrict() async throws {
         // Detected as .docx by the filename hint, but the bytes aren't a zip — the


### PR DESCRIPTION
## Phase 5a — RTFConverter (Tier A polish)

RTF is listed as a supported type but previously threw `documentTypeNotSupported` (it was deferred during the rewrite to avoid reintroducing `NSAttributedString`). This adds a small **pure-Swift** RTF→Markdown parser, so RTF now converts with no `NSAttributedString`, no main-thread hop, and no font-size heading guessing.

### Parser
- Decodes the RTF byte container as Latin-1 (non-ASCII arrives via `\uN` / `\'hh`).
- Walks groups, tracking **bold/italic** on a state stack; emits paragraphs on `\par`/`\row`/`\sect`.
- Skips control tables (`fonttbl`/`colortbl`/`stylesheet`/`info`/`pict`/…) and ignorable (`\*`) destinations.
- Handles `\uN` (with the `\ucN` fallback-skip), `\'hh`, and the common control symbols (`\\ \{ \} \~ \_ \-`).
- RTF has no semantic headings, so none are inferred — deliberately avoiding the lossy font-size→heading guessing the old engine did.

### Wiring & tests
- Registered at `.specific` priority; detection already classifies RTF via the `{\rtf` magic bytes.
- Adds a conversion test (paragraphs + `**bold**`/`*italic*`, control tables skipped, no raw control words leak).
- Drops the now-obsolete "RTF deferred" note from the registry.

First of the **Tier A polish** items (RTF → renderers → DOCX images).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP)_