### PR TITLE
Phase 5b: implement plaintext/HTML/XML/CSV renderers

### DIFF
--- a/Sources/PicoDocs/Renderers/DocumentRenderer.swift
+++ b/Sources/PicoDocs/Renderers/DocumentRenderer.swift
@@ -3,13 +3,12 @@
 //  PicoDocs
 //
 //  Renders a (canonical, structured) `ConverterResult` to a requested
-//  `ExportFileType`. Keeping output formatting here — rather than branching on
-//  format inside each converter — keeps the converter contract simple.
+//  `ExportFileType`. Markdown is the canonical form converters emit; the other
+//  formats are derived from it here, so converters never branch on output format.
 //
-//  Markdown is the canonical form; other formats are derived. Only Markdown is
-//  implemented so far. Notably, plaintext is intentionally *unsupported* rather
-//  than returning raw Markdown: once converters emit real Markdown syntax, a
-//  plaintext export must strip it, so emitting markup would be incorrect.
+//  The non-Markdown renderers parse the Markdown subset PicoDocs produces
+//  (headings, emphasis, links/images, code spans/fences, blockquotes, lists,
+//  pipe tables, rules) rather than implementing a full CommonMark parser.
 //
 
 import Foundation
@@ -19,13 +18,354 @@ public enum DocumentRenderer {
     public static func render(_ result: ConverterResult, to format: ExportFileType) throws -> String {
         switch format {
         case .markdown:
-            return result.sections.map(\.markdown).joined(separator: "\n\n")
-        case .plaintext, .html, .xml, .csv:
-            // TODO: implement these renderers alongside the converters that emit
-            // the structured Markdown/tables they need. Plaintext requires a
-            // Markdown-stripping pass; returning raw Markdown here would leak
-            // syntax (headings, links, emphasis) into a "plaintext" export.
-            throw PicoDocsError.unableToExportToRequestedFormat
+            return result.markdown()
+        case .plaintext:
+            return renderPlaintext(result)
+        case .html:
+            return renderHTML(result)
+        case .xml:
+            return renderXML(result)
+        case .csv:
+            return renderCSV(result)
         }
+    }
+
+    // MARK: - Plaintext
+
+    private static func renderPlaintext(_ result: ConverterResult) -> String {
+        var out: [String] = []
+        for block in parseBlocks(result.markdown()) {
+            switch block {
+            case .heading(_, let text):
+                out.append(stripInline(text))
+            case .paragraph(let text):
+                out.append(stripInline(text))
+            case .code(let code):
+                out.append(code)
+            case .rule:
+                out.append("")
+            case .blockquote(let lines):
+                out.append(lines.map { stripInline($0) }.joined(separator: "\n"))
+            case .list(let ordered, let items):
+                let rendered = items.enumerated().map { index, item in
+                    let marker = ordered ? "\(index + 1). " : "- "
+                    return marker + stripInline(item).replacingOccurrences(of: "\n", with: " ")
+                }
+                out.append(rendered.joined(separator: "\n"))
+            case .table(let rows):
+                out.append(rows.map { $0.map { stripInline($0) }.joined(separator: "\t") }.joined(separator: "\n"))
+            }
+        }
+        return out.joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - HTML
+
+    private static func renderHTML(_ result: ConverterResult) -> String {
+        var body: [String] = []
+        for block in parseBlocks(result.markdown()) {
+            switch block {
+            case .heading(let level, let text):
+                body.append("<h\(level)>\(inlineHTML(text))</h\(level)>")
+            case .paragraph(let text):
+                let html = inlineHTML(text).replacingOccurrences(of: "\n", with: "<br>\n")
+                body.append("<p>\(html)</p>")
+            case .code(let code):
+                body.append("<pre><code>\(escapeHTML(code))</code></pre>")
+            case .rule:
+                body.append("<hr>")
+            case .blockquote(let lines):
+                let inner = lines.map { inlineHTML($0) }.joined(separator: "<br>\n")
+                body.append("<blockquote>\(inner)</blockquote>")
+            case .list(let ordered, let items):
+                let tag = ordered ? "ol" : "ul"
+                let lis = items.map { "<li>\(inlineHTML($0).replacingOccurrences(of: "\n", with: " "))</li>" }
+                body.append("<\(tag)>\n\(lis.joined(separator: "\n"))\n</\(tag)>")
+            case .table(let rows):
+                body.append(renderHTMLTable(rows))
+            }
+        }
+        let title = result.title.map { "<title>\(escapeHTML($0))</title>\n" } ?? ""
+        return """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="utf-8">
+        \(title)</head>
+        <body>
+        \(body.joined(separator: "\n"))
+        </body>
+        </html>
+        """
+    }
+
+    private static func renderHTMLTable(_ rows: [[String]]) -> String {
+        guard let header = rows.first else { return "" }
+        var out = "<table>\n<thead>\n<tr>"
+        out += header.map { "<th>\(inlineHTML($0))</th>" }.joined()
+        out += "</tr>\n</thead>\n<tbody>\n"
+        for row in rows.dropFirst() {
+            out += "<tr>" + row.map { "<td>\(inlineHTML($0))</td>" }.joined() + "</tr>\n"
+        }
+        out += "</tbody>\n</table>"
+        return out
+    }
+
+    // MARK: - XML
+
+    private static func renderXML(_ result: ConverterResult) -> String {
+        var out = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<document"
+        if let title = result.title { out += " title=\"\(escapeXMLAttribute(title))\"" }
+        if let author = result.author { out += " author=\"\(escapeXMLAttribute(author))\"" }
+        out += ">\n"
+        for section in result.sections {
+            out += "  <section kind=\"\(section.kind.rawValue)\""
+            if let title = section.title { out += " title=\"\(escapeXMLAttribute(title))\"" }
+            out += ">\n"
+            out += "    \(escapeXML(section.markdown))\n"
+            out += "  </section>\n"
+        }
+        out += "</document>"
+        return out
+    }
+
+    // MARK: - CSV
+
+    /// Emits CSV from the document's Markdown: pipe-table rows become CSV rows,
+    /// and any other non-blank line becomes a single-field row, so spreadsheet
+    /// exports are clean and prose isn't silently dropped.
+    private static func renderCSV(_ result: ConverterResult) -> String {
+        var rows: [String] = []
+        for rawLine in result.markdown().components(separatedBy: "\n") {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty { continue }
+            if line.hasPrefix("|") {
+                let cells = parseTableRow(rawLine).map { unescapePipes($0) }
+                if isTableSeparatorRow(cells) { continue }
+                rows.append(cells.map { csvField($0) }.joined(separator: ","))
+            } else {
+                rows.append(csvField(stripInline(line)))
+            }
+        }
+        return rows.joined(separator: "\n")
+    }
+
+    // MARK: - Markdown block parsing
+
+    private enum Block {
+        case heading(Int, String)
+        case paragraph(String)
+        case code(String)
+        case blockquote([String])
+        case list(ordered: Bool, items: [String])
+        case table([[String]])
+        case rule
+    }
+
+    private static func parseBlocks(_ markdown: String) -> [Block] {
+        let lines = markdown.components(separatedBy: "\n")
+        var blocks: [Block] = []
+        var i = 0
+
+        func isBlank(_ s: String) -> Bool { s.trimmingCharacters(in: .whitespaces).isEmpty }
+
+        while i < lines.count {
+            let line = lines[i]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if isBlank(line) { i += 1; continue }
+
+            if trimmed.hasPrefix("```") {
+                i += 1
+                var code: [String] = []
+                while i < lines.count, !lines[i].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+                    code.append(lines[i]); i += 1
+                }
+                if i < lines.count { i += 1 }   // closing fence
+                blocks.append(.code(code.joined(separator: "\n")))
+                continue
+            }
+
+            if trimmed == "---" || trimmed == "***" || trimmed == "___" {
+                blocks.append(.rule); i += 1; continue
+            }
+
+            if let heading = headingMatch(trimmed) {
+                blocks.append(.heading(heading.level, heading.text)); i += 1; continue
+            }
+
+            if trimmed.hasPrefix("|") {
+                var rows: [[String]] = []
+                while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces).hasPrefix("|") {
+                    let cells = parseTableRow(lines[i]).map { unescapePipes($0) }
+                    if !isTableSeparatorRow(cells) { rows.append(cells) }
+                    i += 1
+                }
+                if !rows.isEmpty { blocks.append(.table(rows)) }
+                continue
+            }
+
+            if trimmed.hasPrefix(">") {
+                var inner: [String] = []
+                while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces).hasPrefix(">") {
+                    var quoted = lines[i].trimmingCharacters(in: .whitespaces)
+                    quoted.removeFirst()                       // ">"
+                    if quoted.hasPrefix(" ") { quoted.removeFirst() }
+                    inner.append(quoted)
+                    i += 1
+                }
+                blocks.append(.blockquote(inner)); continue
+            }
+
+            if listMarker(trimmed) != nil {
+                let ordered = listMarker(trimmed) == .ordered
+                var items: [String] = []
+                while i < lines.count {
+                    let itemLine = lines[i].trimmingCharacters(in: .whitespaces)
+                    if let marker = listMarker(itemLine), (marker == .ordered) == ordered {
+                        items.append(stripListMarker(itemLine)); i += 1
+                    } else if !isBlank(lines[i]), lines[i].hasPrefix("  "), !items.isEmpty {
+                        items[items.count - 1] += "\n" + lines[i].trimmingCharacters(in: .whitespaces)
+                        i += 1
+                    } else {
+                        break
+                    }
+                }
+                blocks.append(.list(ordered: ordered, items: items)); continue
+            }
+
+            // Paragraph: gather until a blank line or a structural line.
+            var paragraph: [String] = []
+            while i < lines.count {
+                let candidate = lines[i].trimmingCharacters(in: .whitespaces)
+                if isBlank(lines[i]) || candidate.hasPrefix("```") || candidate.hasPrefix("|")
+                    || candidate.hasPrefix(">") || candidate == "---" || candidate == "***"
+                    || headingMatch(candidate) != nil || listMarker(candidate) != nil {
+                    break
+                }
+                paragraph.append(lines[i]); i += 1
+            }
+            if !paragraph.isEmpty {
+                blocks.append(.paragraph(paragraph.joined(separator: "\n")))
+            }
+        }
+        return blocks
+    }
+
+    private static func headingMatch(_ line: String) -> (level: Int, text: String)? {
+        var level = 0
+        var index = line.startIndex
+        while index < line.endIndex, line[index] == "#", level < 6 {
+            level += 1; index = line.index(after: index)
+        }
+        guard level > 0, index < line.endIndex, line[index] == " " else { return nil }
+        let text = String(line[line.index(after: index)...]).trimmingCharacters(in: .whitespaces)
+        return (level, text)
+    }
+
+    private enum ListKind: Equatable { case ordered, unordered }
+
+    private static func listMarker(_ line: String) -> ListKind? {
+        if line.hasPrefix("- ") || line.hasPrefix("* ") || line.hasPrefix("+ ") { return .unordered }
+        // ordered: one-or-more digits, then ". "
+        var index = line.startIndex
+        var digits = 0
+        while index < line.endIndex, line[index].isNumber { digits += 1; index = line.index(after: index) }
+        if digits > 0, index < line.endIndex, line[index] == "." {
+            let after = line.index(after: index)
+            if after < line.endIndex, line[after] == " " { return .ordered }
+        }
+        return nil
+    }
+
+    private static func stripListMarker(_ line: String) -> String {
+        if line.hasPrefix("- ") || line.hasPrefix("* ") || line.hasPrefix("+ ") {
+            return String(line.dropFirst(2))
+        }
+        if let dot = line.firstIndex(of: "."), line[line.startIndex..<dot].allSatisfy(\.isNumber) {
+            return String(line[line.index(after: dot)...]).trimmingCharacters(in: .whitespaces)
+        }
+        return line
+    }
+
+    private static func parseTableRow(_ line: String) -> [String] {
+        var cells = line.trimmingCharacters(in: .whitespaces)
+        if cells.hasPrefix("|") { cells.removeFirst() }
+        if cells.hasSuffix("|") { cells.removeLast() }
+        // Split on unescaped pipes only.
+        var result: [String] = []
+        var current = ""
+        var previous: Character?
+        for character in cells {
+            if character == "|", previous != "\\" {
+                result.append(current.trimmingCharacters(in: .whitespaces))
+                current = ""
+            } else {
+                current.append(character)
+            }
+            previous = character
+        }
+        result.append(current.trimmingCharacters(in: .whitespaces))
+        return result
+    }
+
+    private static func isTableSeparatorRow(_ cells: [String]) -> Bool {
+        guard !cells.isEmpty else { return false }
+        return cells.allSatisfy { cell in
+            let trimmed = cell.trimmingCharacters(in: .whitespaces)
+            return !trimmed.isEmpty && trimmed.allSatisfy { $0 == "-" || $0 == ":" }
+        }
+    }
+
+    private static func unescapePipes(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\|", with: "|")
+    }
+
+    // MARK: - Inline rendering
+
+    /// Converts inline Markdown to HTML on an HTML-escaped string.
+    private static func inlineHTML(_ text: String) -> String {
+        var result = escapeHTML(text)
+        result = result.replacingOccurrences(of: "`([^`]+)`", with: "<code>$1</code>", options: .regularExpression)
+        result = result.replacingOccurrences(of: "!\\[([^\\]]*)\\]\\(([^)]+)\\)", with: "<img src=\"$2\" alt=\"$1\">", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\[([^\\]]*)\\]\\(([^)]+)\\)", with: "<a href=\"$2\">$1</a>", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\*\\*([^*]+)\\*\\*", with: "<strong>$1</strong>", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\*([^*]+)\\*", with: "<em>$1</em>", options: .regularExpression)
+        return result
+    }
+
+    /// Strips inline Markdown to plain text (links/images become their label/alt).
+    private static func stripInline(_ text: String) -> String {
+        var result = text
+        result = result.replacingOccurrences(of: "!\\[([^\\]]*)\\]\\(([^)]+)\\)", with: "$1", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\[([^\\]]*)\\]\\(([^)]+)\\)", with: "$1", options: .regularExpression)
+        result = result.replacingOccurrences(of: "`([^`]+)`", with: "$1", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\*\\*([^*]+)\\*\\*", with: "$1", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\*([^*]+)\\*", with: "$1", options: .regularExpression)
+        return result
+    }
+
+    // MARK: - Escaping
+
+    private static func escapeHTML(_ text: String) -> String {
+        text.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+    }
+
+    private static func escapeXML(_ text: String) -> String {
+        escapeHTML(text)
+    }
+
+    private static func escapeXMLAttribute(_ text: String) -> String {
+        escapeHTML(text).replacingOccurrences(of: "\"", with: "&quot;")
+    }
+
+    /// Quotes a CSV field per RFC 4180 when it contains a comma, quote, or newline.
+    private static func csvField(_ value: String) -> String {
+        if value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r") {
+            return "\"" + value.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+        }
+        return value
     }
 }

--- a/Sources/PicoDocs/Renderers/DocumentRenderer.swift
+++ b/Sources/PicoDocs/Renderers/DocumentRenderer.swift
@@ -43,7 +43,7 @@ public enum DocumentRenderer {
             case .code(let code):
                 out.append(code)
             case .rule:
-                out.append("")
+                out.append("---")
             case .blockquote(let lines):
                 out.append(lines.map { stripInline($0) }.joined(separator: "\n"))
             case .list(let ordered, let items):
@@ -136,15 +136,26 @@ public enum DocumentRenderer {
     /// exports are clean and prose isn't silently dropped.
     private static func renderCSV(_ result: ConverterResult) -> String {
         var rows: [String] = []
-        for rawLine in result.markdown().components(separatedBy: "\n") {
-            let line = rawLine.trimmingCharacters(in: .whitespaces)
-            if line.isEmpty { continue }
+        let lines = result.markdown().components(separatedBy: "\n")
+        var i = 0
+        while i < lines.count {
+            let line = lines[i].trimmingCharacters(in: .whitespaces)
+            if line.isEmpty { i += 1; continue }
             if line.hasPrefix("|") {
-                let cells = parseTableRow(rawLine).map { unescapePipes($0) }
-                if isTableSeparatorRow(cells) { continue }
-                rows.append(cells.map { csvField($0) }.joined(separator: ","))
+                // Within a run of table rows, drop only the conventional separator
+                // (second row), so all-dash data rows elsewhere are preserved.
+                var rowIndex = 0
+                while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces).hasPrefix("|") {
+                    let cells = parseTableRow(lines[i]).map { unescapePipes($0) }
+                    if !(rowIndex == 1 && isTableSeparatorRow(cells)) {
+                        rows.append(cells.map { csvField($0) }.joined(separator: ","))
+                    }
+                    rowIndex += 1
+                    i += 1
+                }
             } else {
                 rows.append(csvField(stripInline(line)))
+                i += 1
             }
         }
         return rows.joined(separator: "\n")
@@ -196,9 +207,14 @@ public enum DocumentRenderer {
 
             if trimmed.hasPrefix("|") {
                 var rows: [[String]] = []
+                var rowIndex = 0
                 while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces).hasPrefix("|") {
                     let cells = parseTableRow(lines[i]).map { unescapePipes($0) }
-                    if !isTableSeparatorRow(cells) { rows.append(cells) }
+                    // The header/body separator is conventionally the second row;
+                    // only drop an all-dash row there, so real data rows that
+                    // happen to be all dashes elsewhere are kept.
+                    if !(rowIndex == 1 && isTableSeparatorRow(cells)) { rows.append(cells) }
+                    rowIndex += 1
                     i += 1
                 }
                 if !rows.isEmpty { blocks.append(.table(rows)) }
@@ -323,25 +339,62 @@ public enum DocumentRenderer {
 
     // MARK: - Inline rendering
 
-    /// Converts inline Markdown to HTML on an HTML-escaped string.
+    // Sentinels that bracket extracted code spans; private-use scalars that won't
+    // appear in document text and aren't touched by escaping or emphasis regexes.
+    private static let codeOpen = "\u{E000}"
+    private static let codeClose = "\u{E001}"
+
+    /// Replaces inline code spans with placeholders so the link/emphasis passes
+    /// don't rewrite Markdown metacharacters inside code. Returns the rewritten
+    /// text and the captured span contents (in order).
+    private static func extractCodeSpans(_ text: String) -> (text: String, spans: [String]) {
+        var spans: [String] = []
+        var result = ""
+        var index = text.startIndex
+        while index < text.endIndex {
+            if text[index] == "`",
+               let close = text[text.index(after: index)...].firstIndex(of: "`") {
+                spans.append(String(text[text.index(after: index)..<close]))
+                result += "\(codeOpen)\(spans.count - 1)\(codeClose)"
+                index = text.index(after: close)
+            } else {
+                result.append(text[index])
+                index = text.index(after: index)
+            }
+        }
+        return (result, spans)
+    }
+
+    /// Converts inline Markdown to HTML. Code spans are protected first; remaining
+    /// text is HTML-escaped (so links/images can't break out of attributes), then
+    /// images, links, and emphasis are applied.
     private static func inlineHTML(_ text: String) -> String {
-        var result = escapeHTML(text)
-        result = result.replacingOccurrences(of: "`([^`]+)`", with: "<code>$1</code>", options: .regularExpression)
+        let (protectedText, spans) = extractCodeSpans(text)
+        var result = escapeHTML(protectedText)
         result = result.replacingOccurrences(of: "!\\[([^\\]]*)\\]\\(([^)]+)\\)", with: "<img src=\"$2\" alt=\"$1\">", options: .regularExpression)
         result = result.replacingOccurrences(of: "\\[([^\\]]*)\\]\\(([^)]+)\\)", with: "<a href=\"$2\">$1</a>", options: .regularExpression)
-        result = result.replacingOccurrences(of: "\\*\\*([^*]+)\\*\\*", with: "<strong>$1</strong>", options: .regularExpression)
-        result = result.replacingOccurrences(of: "\\*([^*]+)\\*", with: "<em>$1</em>", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\*\\*\\*(.+?)\\*\\*\\*", with: "<strong><em>$1</em></strong>", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\*\\*(.+?)\\*\\*", with: "<strong>$1</strong>", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\*(.+?)\\*", with: "<em>$1</em>", options: .regularExpression)
+        for (index, span) in spans.enumerated() {
+            result = result.replacingOccurrences(of: "\(codeOpen)\(index)\(codeClose)", with: "<code>\(escapeHTML(span))</code>")
+        }
         return result
     }
 
-    /// Strips inline Markdown to plain text (links/images become their label/alt).
+    /// Strips inline Markdown to plain text (links/images become their label/alt;
+    /// code spans keep their literal contents).
     private static func stripInline(_ text: String) -> String {
-        var result = text
+        let (protectedText, spans) = extractCodeSpans(text)
+        var result = protectedText
         result = result.replacingOccurrences(of: "!\\[([^\\]]*)\\]\\(([^)]+)\\)", with: "$1", options: .regularExpression)
         result = result.replacingOccurrences(of: "\\[([^\\]]*)\\]\\(([^)]+)\\)", with: "$1", options: .regularExpression)
-        result = result.replacingOccurrences(of: "`([^`]+)`", with: "$1", options: .regularExpression)
-        result = result.replacingOccurrences(of: "\\*\\*([^*]+)\\*\\*", with: "$1", options: .regularExpression)
-        result = result.replacingOccurrences(of: "\\*([^*]+)\\*", with: "$1", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\*\\*\\*(.+?)\\*\\*\\*", with: "$1", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\*\\*(.+?)\\*\\*", with: "$1", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\*(.+?)\\*", with: "$1", options: .regularExpression)
+        for (index, span) in spans.enumerated() {
+            result = result.replacingOccurrences(of: "\(codeOpen)\(index)\(codeClose)", with: span)
+        }
         return result
     }
 
@@ -351,14 +404,17 @@ public enum DocumentRenderer {
         text.replacingOccurrences(of: "&", with: "&amp;")
             .replacingOccurrences(of: "<", with: "&lt;")
             .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
     }
 
     private static func escapeXML(_ text: String) -> String {
         escapeHTML(text)
     }
 
+    // `escapeHTML` already escapes the double quote, so attribute values are safe.
     private static func escapeXMLAttribute(_ text: String) -> String {
-        escapeHTML(text).replacingOccurrences(of: "\"", with: "&quot;")
+        escapeHTML(text)
     }
 
     /// Quotes a CSV field per RFC 4180 when it contains a comma, quote, or newline.

--- a/Sources/PicoDocs/Renderers/DocumentRenderer.swift
+++ b/Sources/PicoDocs/Renderers/DocumentRenderer.swift
@@ -10,6 +10,13 @@
 //  (headings, emphasis, links/images, code spans/fences, blockquotes, lists,
 //  pipe tables, rules) rather than implementing a full CommonMark parser.
 //
+//  These renderers assume their input is the canonical Markdown the converters
+//  emit. Raw-text and CSV *inputs* are currently stored verbatim by
+//  PlainTextConverter (it doesn't Markdown-escape text or parse CSV into a
+//  table), so re-exporting those specific inputs to plaintext/CSV can drop a
+//  literal `*` or collapse columns — making those round-trips lossless is a
+//  PlainTextConverter follow-up, not a renderer change.
+//
 
 import Foundation
 
@@ -138,8 +145,21 @@ public enum DocumentRenderer {
         var rows: [String] = []
         let lines = result.markdown().components(separatedBy: "\n")
         var i = 0
+        var inCodeFence = false
         while i < lines.count {
             let line = lines[i].trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix("```") {
+                inCodeFence.toggle()
+                i += 1
+                continue
+            }
+            if inCodeFence {
+                // Preserve fenced code verbatim as a single field, so a pipe-
+                // containing code line isn't split into CSV cells.
+                rows.append(csvField(lines[i]))
+                i += 1
+                continue
+            }
             if line.isEmpty { i += 1; continue }
             if line.hasPrefix("|") {
                 // Within a run of table rows, drop only the conventional separator
@@ -339,14 +359,17 @@ public enum DocumentRenderer {
 
     // MARK: - Inline rendering
 
-    // Sentinels that bracket extracted code spans; private-use scalars that won't
+    // Sentinels that bracket extracted spans; private-use scalars that won't
     // appear in document text and aren't touched by escaping or emphasis regexes.
     private static let codeOpen = "\u{E000}"
     private static let codeClose = "\u{E001}"
+    private static let linkOpen = "\u{E002}"
+    private static let linkClose = "\u{E003}"
+
+    private struct InlineLink { let label: String; let url: String; let isImage: Bool }
 
     /// Replaces inline code spans with placeholders so the link/emphasis passes
-    /// don't rewrite Markdown metacharacters inside code. Returns the rewritten
-    /// text and the captured span contents (in order).
+    /// don't rewrite Markdown metacharacters inside code.
     private static func extractCodeSpans(_ text: String) -> (text: String, spans: [String]) {
         var spans: [String] = []
         var result = ""
@@ -365,36 +388,81 @@ public enum DocumentRenderer {
         return (result, spans)
     }
 
-    /// Converts inline Markdown to HTML. Code spans are protected first; remaining
-    /// text is HTML-escaped (so links/images can't break out of attributes), then
-    /// images, links, and emphasis are applied.
+    /// Replaces links/images with placeholders before escaping/emphasis so a URL
+    /// (or alt text) containing emphasis characters isn't rewritten inside the
+    /// generated attribute. Handles CommonMark angle-bracket destinations
+    /// `(<url with spaces (and parens)>)` that WordConverter emits.
+    private static func extractLinks(_ text: String) -> (text: String, links: [InlineLink]) {
+        let pattern = "(!)?\\[([^\\]]*)\\]\\((?:<([^>]+)>|([^)]+))\\)"
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return (text, []) }
+        let ns = text as NSString
+        var links: [InlineLink] = []
+        var result = ""
+        var last = 0
+        for match in regex.matches(in: text, range: NSRange(location: 0, length: ns.length)) {
+            result += ns.substring(with: NSRange(location: last, length: match.range.location - last))
+            let isImage = match.range(at: 1).location != NSNotFound
+            let label = nsSubstring(ns, match.range(at: 2))
+            let url = match.range(at: 3).location != NSNotFound ? nsSubstring(ns, match.range(at: 3)) : nsSubstring(ns, match.range(at: 4))
+            result += "\(linkOpen)\(links.count)\(linkClose)"
+            links.append(InlineLink(label: label, url: url, isImage: isImage))
+            last = match.range.location + match.range.length
+        }
+        result += ns.substring(with: NSRange(location: last, length: ns.length - last))
+        return (result, links)
+    }
+
+    private static func nsSubstring(_ ns: NSString, _ range: NSRange) -> String {
+        range.location == NSNotFound ? "" : ns.substring(with: range)
+    }
+
+    /// Converts inline Markdown to HTML. Code spans and links/images are pulled
+    /// out first (so their contents/URLs aren't touched by escaping or emphasis),
+    /// the remaining text is HTML-escaped and emphasized, then they're restored.
     private static func inlineHTML(_ text: String) -> String {
-        let (protectedText, spans) = extractCodeSpans(text)
-        var result = escapeHTML(protectedText)
-        result = result.replacingOccurrences(of: "!\\[([^\\]]*)\\]\\(([^)]+)\\)", with: "<img src=\"$2\" alt=\"$1\">", options: .regularExpression)
-        result = result.replacingOccurrences(of: "\\[([^\\]]*)\\]\\(([^)]+)\\)", with: "<a href=\"$2\">$1</a>", options: .regularExpression)
-        result = result.replacingOccurrences(of: "\\*\\*\\*(.+?)\\*\\*\\*", with: "<strong><em>$1</em></strong>", options: .regularExpression)
-        result = result.replacingOccurrences(of: "\\*\\*(.+?)\\*\\*", with: "<strong>$1</strong>", options: .regularExpression)
-        result = result.replacingOccurrences(of: "\\*(.+?)\\*", with: "<em>$1</em>", options: .regularExpression)
+        let (afterCode, spans) = extractCodeSpans(text)
+        let (afterLinks, links) = extractLinks(afterCode)
+        var result = applyEmphasisHTML(escapeHTML(afterLinks))
+        for (index, link) in links.enumerated() {
+            let tag = link.isImage
+                ? "<img src=\"\(escapeHTML(link.url))\" alt=\"\(escapeHTML(link.label))\">"
+                : "<a href=\"\(escapeHTML(link.url))\">\(applyEmphasisHTML(escapeHTML(link.label)))</a>"
+            result = result.replacingOccurrences(of: "\(linkOpen)\(index)\(linkClose)", with: tag)
+        }
         for (index, span) in spans.enumerated() {
             result = result.replacingOccurrences(of: "\(codeOpen)\(index)\(codeClose)", with: "<code>\(escapeHTML(span))</code>")
         }
         return result
     }
 
+    private static func applyEmphasisHTML(_ text: String) -> String {
+        var result = text
+        result = result.replacingOccurrences(of: "\\*\\*\\*(.+?)\\*\\*\\*", with: "<strong><em>$1</em></strong>", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\*\\*(.+?)\\*\\*", with: "<strong>$1</strong>", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\*(.+?)\\*", with: "<em>$1</em>", options: .regularExpression)
+        return result
+    }
+
     /// Strips inline Markdown to plain text (links/images become their label/alt;
     /// code spans keep their literal contents).
     private static func stripInline(_ text: String) -> String {
-        let (protectedText, spans) = extractCodeSpans(text)
-        var result = protectedText
-        result = result.replacingOccurrences(of: "!\\[([^\\]]*)\\]\\(([^)]+)\\)", with: "$1", options: .regularExpression)
-        result = result.replacingOccurrences(of: "\\[([^\\]]*)\\]\\(([^)]+)\\)", with: "$1", options: .regularExpression)
-        result = result.replacingOccurrences(of: "\\*\\*\\*(.+?)\\*\\*\\*", with: "$1", options: .regularExpression)
-        result = result.replacingOccurrences(of: "\\*\\*(.+?)\\*\\*", with: "$1", options: .regularExpression)
-        result = result.replacingOccurrences(of: "\\*(.+?)\\*", with: "$1", options: .regularExpression)
+        let (afterCode, spans) = extractCodeSpans(text)
+        let (afterLinks, links) = extractLinks(afterCode)
+        var result = applyEmphasisStrip(afterLinks)
+        for (index, link) in links.enumerated() {
+            result = result.replacingOccurrences(of: "\(linkOpen)\(index)\(linkClose)", with: applyEmphasisStrip(link.label))
+        }
         for (index, span) in spans.enumerated() {
             result = result.replacingOccurrences(of: "\(codeOpen)\(index)\(codeClose)", with: span)
         }
+        return result
+    }
+
+    private static func applyEmphasisStrip(_ text: String) -> String {
+        var result = text
+        result = result.replacingOccurrences(of: "\\*\\*\\*(.+?)\\*\\*\\*", with: "$1", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\*\\*(.+?)\\*\\*", with: "$1", options: .regularExpression)
+        result = result.replacingOccurrences(of: "\\*(.+?)\\*", with: "$1", options: .regularExpression)
         return result
     }
 

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -179,11 +179,54 @@ struct DocumentRendererTests {
         #expect(html.contains("<td>1</td>"))
     }
 
-    @Test("HTML rendering escapes special characters")
+    @Test("HTML rendering escapes special characters including quotes")
     func htmlEscaping() throws {
-        let result = ConverterResult(sections: [DocumentSection(kind: .body, markdown: "1 < 2 & 3 > 0")])
+        let result = ConverterResult(sections: [
+            DocumentSection(kind: .body, markdown: "1 < 2 & 3 > 0 with \"quotes\" and 'single'"),
+        ])
         let html = try DocumentRenderer.render(result, to: .html)
-        #expect(html.contains("1 &lt; 2 &amp; 3 &gt; 0"))
+        #expect(html.contains("1 &lt; 2 &amp; 3 &gt; 0 with &quot;quotes&quot; and &#39;single&#39;"))
+    }
+
+    @Test("HTML rendering escapes quotes in link URLs (no attribute breakout)")
+    func htmlLinkURLEscaping() throws {
+        let result = ConverterResult(sections: [
+            DocumentSection(kind: .body, markdown: "[x](https://e.com/a\" onmouseover=\"alert(1))"),
+        ])
+        let html = try DocumentRenderer.render(result, to: .html)
+        #expect(!html.contains("a\" onmouseover=\"alert"))   // the raw quote cannot close href
+        #expect(html.contains("&quot;"))
+    }
+
+    @Test("HTML rendering handles combined and nested emphasis")
+    func htmlEmphasis() throws {
+        let result = ConverterResult(sections: [
+            DocumentSection(kind: .body, markdown: "***both*** and **bold *inner* bold**"),
+        ])
+        let html = try DocumentRenderer.render(result, to: .html)
+        #expect(html.contains("<strong><em>both</em></strong>"))
+        #expect(html.contains("<strong>bold <em>inner</em> bold</strong>"))
+    }
+
+    @Test("Code spans keep Markdown metacharacters literal")
+    func htmlCodeSpan() throws {
+        let result = ConverterResult(sections: [
+            DocumentSection(kind: .body, markdown: "Use `*value*` literally."),
+        ])
+        let html = try DocumentRenderer.render(result, to: .html)
+        #expect(html.contains("<code>*value*</code>"))
+        #expect(!html.contains("<em>value</em>"))
+    }
+
+    @Test("CSV keeps all-dash data rows after the header separator")
+    func csvAllDashDataRow() throws {
+        let result = ConverterResult(sections: [
+            DocumentSection(kind: .sheet, markdown: "| A | B |\n| --- | --- |\n| - | - |\n| 1 | 2 |"),
+        ])
+        let csv = try DocumentRenderer.render(result, to: .csv)
+        #expect(csv.contains("A,B"))
+        #expect(csv.contains("-,-"))      // the all-dash DATA row is preserved
+        #expect(csv.contains("1,2"))
     }
 
     @Test("Plaintext rendering strips Markdown syntax")

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -264,4 +264,34 @@ struct DocumentRendererTests {
         #expect(xml.contains("<section kind=\"body\" title=\"S\">"))
         #expect(xml.contains("a &lt; b"))
     }
+
+    @Test("Emphasis characters in a link URL aren't rewritten; label emphasis is kept")
+    func htmlLinkURLEmphasis() throws {
+        let result = ConverterResult(sections: [
+            DocumentSection(kind: .body, markdown: "[x](https://e.com/*id*) and [**bold**](https://e.com)"),
+        ])
+        let html = try DocumentRenderer.render(result, to: .html)
+        #expect(html.contains("href=\"https://e.com/*id*\""))   // URL kept literal
+        #expect(!html.contains("<em>id</em>"))
+        #expect(html.contains("<a href=\"https://e.com\"><strong>bold</strong></a>"))
+    }
+
+    @Test("HTML handles angle-bracket link destinations with spaces and parens")
+    func htmlAngleBracketLink() throws {
+        let result = ConverterResult(sections: [
+            DocumentSection(kind: .body, markdown: "[label](<https://e.com/a b(1)>)"),
+        ])
+        let html = try DocumentRenderer.render(result, to: .html)
+        #expect(html.contains("<a href=\"https://e.com/a b(1)\">label</a>"))
+    }
+
+    @Test("CSV preserves fenced code lines instead of splitting them")
+    func csvCodeFence() throws {
+        let result = ConverterResult(sections: [
+            DocumentSection(kind: .body, markdown: "Code:\n\n```\n| grep foo | wc -l |\n```"),
+        ])
+        let csv = try DocumentRenderer.render(result, to: .csv)
+        #expect(csv.contains("| grep foo | wc -l |"))
+        #expect(!csv.contains("grep foo,wc -l"))
+    }
 }

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -166,11 +166,59 @@ struct DocumentRendererTests {
         #expect(rendered.contains("second"))
     }
 
-    @Test("Unimplemented formats throw rather than leak Markdown")
-    func unsupportedFormatThrows() {
-        let result = ConverterResult(sections: [DocumentSection(kind: .body, markdown: "x")])
-        #expect(throws: PicoDocsError.self) {
-            _ = try DocumentRenderer.render(result, to: .html)
-        }
+    @Test("HTML rendering converts headings, emphasis, links, and tables")
+    func html() throws {
+        let result = ConverterResult(title: "Doc", sections: [
+            DocumentSection(kind: .body, markdown: "# Title\n\nHello **world** and a [link](https://example.com).\n\n| A | B |\n| --- | --- |\n| 1 | 2 |"),
+        ])
+        let html = try DocumentRenderer.render(result, to: .html)
+        #expect(html.contains("<h1>Title</h1>"))
+        #expect(html.contains("<strong>world</strong>"))
+        #expect(html.contains("<a href=\"https://example.com\">link</a>"))
+        #expect(html.contains("<th>A</th>"))
+        #expect(html.contains("<td>1</td>"))
+    }
+
+    @Test("HTML rendering escapes special characters")
+    func htmlEscaping() throws {
+        let result = ConverterResult(sections: [DocumentSection(kind: .body, markdown: "1 < 2 & 3 > 0")])
+        let html = try DocumentRenderer.render(result, to: .html)
+        #expect(html.contains("1 &lt; 2 &amp; 3 &gt; 0"))
+    }
+
+    @Test("Plaintext rendering strips Markdown syntax")
+    func plaintext() throws {
+        let result = ConverterResult(sections: [
+            DocumentSection(kind: .body, markdown: "# Heading\n\nHello **world** with a [link](https://example.com)."),
+        ])
+        let text = try DocumentRenderer.render(result, to: .plaintext)
+        #expect(text.contains("Heading"))
+        #expect(text.contains("Hello world with a link."))
+        #expect(!text.contains("**"))
+        #expect(!text.contains("#"))
+        #expect(!text.contains("]("))
+    }
+
+    @Test("CSV rendering turns Markdown tables into CSV rows")
+    func csv() throws {
+        let result = ConverterResult(sections: [
+            DocumentSection(kind: .sheet, markdown: "| Name | Score |\n| --- | --- |\n| Alice | 42 |\n| Bob, Jr | 7 |"),
+        ])
+        let csv = try DocumentRenderer.render(result, to: .csv)
+        #expect(csv.contains("Name,Score"))
+        #expect(csv.contains("Alice,42"))
+        #expect(csv.contains("\"Bob, Jr\",7"))   // a field with a comma is quoted
+    }
+
+    @Test("XML rendering wraps sections with escaped content")
+    func xml() throws {
+        let result = ConverterResult(title: "T & U", sections: [
+            DocumentSection(title: "S", kind: .body, markdown: "a < b"),
+        ])
+        let xml = try DocumentRenderer.render(result, to: .xml)
+        #expect(xml.contains("<?xml version=\"1.0\""))
+        #expect(xml.contains("title=\"T &amp; U\""))
+        #expect(xml.contains("<section kind=\"body\" title=\"S\">"))
+        #expect(xml.contains("a &lt; b"))
     }
 }


### PR DESCRIPTION
## Phase 5b — plaintext / HTML / XML / CSV renderers (Tier A polish)

`DocumentRenderer` previously threw `unableToExportToRequestedFormat` for every `ExportFileType` except Markdown, so `PicoDocument.parse(to:)` and the example app's format picker only worked for Markdown. This implements the remaining formats by deriving them from the canonical Markdown the converters emit (converters still never branch on output format).

- **plaintext** — strips Markdown syntax (headings/emphasis/links/images/code) to readable text; tables become tab-separated rows.
- **html** — a full HTML document: headings, paragraphs (`<br>` for soft breaks), emphasis, links/images, code spans/fences, blockquotes, ordered/unordered lists, pipe tables (`thead`/`tbody`), and rules. All text is HTML-escaped.
- **xml** — a structured `<document>` / `<section kind=…>` wrapper with escaped content and `title`/`author` attributes.
- **csv** — Markdown pipe tables become RFC-4180 CSV rows (the `---` separator row is dropped; fields containing commas/quotes/newlines are quoted). Other non-blank lines become single-field rows so prose isn't silently dropped.

A small shared **block parser** handles the Markdown subset PicoDocs produces (headings, emphasis, links/images, code, blockquotes, lists, pipe tables, rules) — no full CommonMark dependency. Inline handling is regex-based against that known subset.

Replaces the renderer's throwing test with per-format tests (escaping, tables, CSV quoting). Second of the **Tier A polish** items (RTF ✅ → renderers → DOCX images).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP)_