### PR TITLE
Phase 6a: structure-aware CSVConverter (CSV → Markdown table)

### DIFF
--- a/Sources/PicoDocs/Converters/CSVConverter.swift
+++ b/Sources/PicoDocs/Converters/CSVConverter.swift
@@ -42,46 +42,51 @@ public struct CSVConverter: DocumentConverter {
         var row: [String] = []
         var field = ""
         var inQuotes = false
-        let characters = Array(text)
-        var i = 0
+
+        // Iterate the unicode-scalar view (delimiters are ASCII) rather than
+        // materializing a `[Character]`, to avoid a full copy of large inputs.
+        let scalars = text.unicodeScalars
+        var index = scalars.startIndex
 
         func endField() { row.append(field); field = "" }
         func endRow() { endField(); rows.append(row); row = [] }
 
-        while i < characters.count {
-            let character = characters[i]
+        while index < scalars.endIndex {
+            let scalar = scalars[index]
             if inQuotes {
-                if character == "\"" {
-                    if i + 1 < characters.count, characters[i + 1] == "\"" {
-                        field.append("\"")   // escaped quote ("")
-                        i += 2
+                if scalar == "\"" {
+                    let next = scalars.index(after: index)
+                    if next < scalars.endIndex, scalars[next] == "\"" {
+                        field.unicodeScalars.append("\"")   // escaped quote ("")
+                        index = scalars.index(after: next)
                     } else {
                         inQuotes = false
-                        i += 1
+                        index = next
                     }
                 } else {
-                    field.append(character)
-                    i += 1
+                    field.unicodeScalars.append(scalar)
+                    index = scalars.index(after: index)
                 }
                 continue
             }
-            switch character {
+            switch scalar {
             case "\"":
                 inQuotes = true
-                i += 1
+                index = scalars.index(after: index)
             case ",":
                 endField()
-                i += 1
+                index = scalars.index(after: index)
             case "\r":
-                if i + 1 < characters.count, characters[i + 1] == "\n" { i += 1 }   // CRLF
                 endRow()
-                i += 1
+                let next = scalars.index(after: index)
+                index = (next < scalars.endIndex && scalars[next] == "\n")   // CRLF
+                    ? scalars.index(after: next) : next
             case "\n":
                 endRow()
-                i += 1
+                index = scalars.index(after: index)
             default:
-                field.append(character)
-                i += 1
+                field.unicodeScalars.append(scalar)
+                index = scalars.index(after: index)
             }
         }
         // Flush the final field/row, ignoring a trailing newline's empty row.

--- a/Sources/PicoDocs/Converters/CSVConverter.swift
+++ b/Sources/PicoDocs/Converters/CSVConverter.swift
@@ -1,0 +1,119 @@
+//
+//  CSVConverter.swift
+//  PicoDocs
+//
+//  Converts CSV to a Markdown table (RFC 4180: quoted fields, escaped quotes,
+//  embedded commas/newlines). Producing a real table — rather than raw comma
+//  lines — gives better Markdown/HTML/CSV exports and round-trips through the
+//  CSV renderer. Registered at specific priority so it handles `.csv` ahead of
+//  the generic plain-text converter.
+//
+
+import Foundation
+
+public struct CSVConverter: DocumentConverter {
+
+    public init() {}
+
+    public func accepts(_ info: StreamInfo) -> Bool {
+        info.detectedFormat == .csv
+    }
+
+    public func convert(_ data: Data, info: StreamInfo) async throws -> ConverterResult {
+        let encoding = info.charset ?? .utf8
+        let decoded = String(data: data, encoding: encoding)
+            ?? (encoding != .utf8 ? String(data: data, encoding: .utf8) : nil)
+        guard let text = decoded else {
+            throw ConverterError.decodingFailed
+        }
+        let rows = Self.parseCSV(text)
+        let table = Self.markdownTable(rows)
+        guard !table.isEmpty else { throw PicoDocsError.emptyDocument }
+        return ConverterResult(
+            title: info.filename,
+            sections: [DocumentSection(title: info.filename, kind: .table, markdown: table)]
+        )
+    }
+
+    // MARK: - CSV parsing (RFC 4180)
+
+    static func parseCSV(_ text: String) -> [[String]] {
+        var rows: [[String]] = []
+        var row: [String] = []
+        var field = ""
+        var inQuotes = false
+        let characters = Array(text)
+        var i = 0
+
+        func endField() { row.append(field); field = "" }
+        func endRow() { endField(); rows.append(row); row = [] }
+
+        while i < characters.count {
+            let character = characters[i]
+            if inQuotes {
+                if character == "\"" {
+                    if i + 1 < characters.count, characters[i + 1] == "\"" {
+                        field.append("\"")   // escaped quote ("")
+                        i += 2
+                    } else {
+                        inQuotes = false
+                        i += 1
+                    }
+                } else {
+                    field.append(character)
+                    i += 1
+                }
+                continue
+            }
+            switch character {
+            case "\"":
+                inQuotes = true
+                i += 1
+            case ",":
+                endField()
+                i += 1
+            case "\r":
+                if i + 1 < characters.count, characters[i + 1] == "\n" { i += 1 }   // CRLF
+                endRow()
+                i += 1
+            case "\n":
+                endRow()
+                i += 1
+            default:
+                field.append(character)
+                i += 1
+            }
+        }
+        // Flush the final field/row, ignoring a trailing newline's empty row.
+        if !field.isEmpty || !row.isEmpty {
+            endRow()
+        }
+        return rows
+    }
+
+    // MARK: - Markdown table
+
+    static func markdownTable(_ rows: [[String]]) -> String {
+        let columnCount = rows.map(\.count).max() ?? 0
+        guard columnCount > 0 else { return "" }
+
+        func cell(_ value: String) -> String {
+            value
+                .replacingOccurrences(of: "|", with: "\\|")
+                .replacingOccurrences(of: "\r\n", with: " ")
+                .replacingOccurrences(of: "\r", with: " ")
+                .replacingOccurrences(of: "\n", with: " ")
+                .trimmingCharacters(in: .whitespaces)
+        }
+        func pad(_ row: [String]) -> [String] {
+            row.map(cell) + Array(repeating: "", count: max(0, columnCount - row.count))
+        }
+
+        var out = "| " + pad(rows[0]).joined(separator: " | ") + " |\n"
+        out += "| " + Array(repeating: "---", count: columnCount).joined(separator: " | ") + " |"
+        for row in rows.dropFirst() {
+            out += "\n| " + pad(row).joined(separator: " | ") + " |"
+        }
+        return out
+    }
+}

--- a/Sources/PicoDocs/Converters/CSVConverter.swift
+++ b/Sources/PicoDocs/Converters/CSVConverter.swift
@@ -68,6 +68,10 @@ public struct CSVConverter: DocumentConverter {
         var row: [String] = []
         var field = ""
         var inQuotes = false
+        // Whether the current record has begun a field (content, a quote, or a
+        // comma). Distinguishes a real final empty field (e.g. a closing `""`)
+        // from "nothing after the last newline", which must not be emitted.
+        var fieldStarted = false
 
         // Iterate the unicode-scalar view (delimiters are ASCII) rather than
         // materializing a `[Character]`, to avoid a full copy of large inputs.
@@ -75,11 +79,12 @@ public struct CSVConverter: DocumentConverter {
         var index = scalars.startIndex
 
         func endField() { row.append(field); field = "" }
-        func endRow() { endField(); rows.append(row); row = [] }
+        func endRow() { endField(); rows.append(row); row = []; fieldStarted = false }
 
         while index < scalars.endIndex {
             let scalar = scalars[index]
             if inQuotes {
+                fieldStarted = true
                 if scalar == "\"" {
                     let next = scalars.index(after: index)
                     if next < scalars.endIndex, scalars[next] == "\"" {
@@ -98,8 +103,10 @@ public struct CSVConverter: DocumentConverter {
             switch scalar {
             case "\"":
                 inQuotes = true
+                fieldStarted = true
                 index = scalars.index(after: index)
             case ",":
+                fieldStarted = true
                 endField()
                 index = scalars.index(after: index)
             case "\r":
@@ -111,12 +118,14 @@ public struct CSVConverter: DocumentConverter {
                 endRow()
                 index = scalars.index(after: index)
             default:
+                fieldStarted = true
                 field.unicodeScalars.append(scalar)
                 index = scalars.index(after: index)
             }
         }
-        // Flush the final field/row, ignoring a trailing newline's empty row.
-        if !field.isEmpty || !row.isEmpty {
+        // Flush the final record, but skip a phantom row from a trailing newline
+        // (nothing started since the last row end).
+        if fieldStarted || !field.isEmpty || !row.isEmpty {
             endRow()
         }
         return rows

--- a/Sources/PicoDocs/Converters/CSVConverter.swift
+++ b/Sources/PicoDocs/Converters/CSVConverter.swift
@@ -29,10 +29,36 @@ public struct CSVConverter: DocumentConverter {
         let rows = Self.parseCSV(text)
         let table = Self.markdownTable(rows)
         guard !table.isEmpty else { throw PicoDocsError.emptyDocument }
-        return ConverterResult(
+        // A single-line Markdown table cell is great for display/RAG but can't
+        // hold embedded newlines or leading/trailing spaces. Keep a lossless,
+        // canonical CSV serialization in metadata so CSV export round-trips those
+        // values exactly (the renderer prefers it over re-parsing the table).
+        let section = DocumentSection(
             title: info.filename,
-            sections: [DocumentSection(title: info.filename, kind: .table, markdown: table)]
+            kind: .table,
+            markdown: table,
+            metadata: ["csv": Self.serializeCSV(rows)]
         )
+        return ConverterResult(title: info.filename, sections: [section])
+    }
+
+    /// Serializes rows to canonical RFC 4180 CSV (quoting fields that contain a
+    /// comma, quote, or newline), preserving cell values exactly.
+    static func serializeCSV(_ rows: [[String]]) -> String {
+        rows.map { row in row.map(csvField).joined(separator: ",") }.joined(separator: "\n")
+    }
+
+    private static func csvField(_ value: String) -> String {
+        // Quote on delimiters/quotes/newlines, and also on leading/trailing
+        // whitespace (otherwise parsers that strip unquoted fields would drop it).
+        let hasEdgeWhitespace = value.first == " " || value.last == " "
+            || value.first == "\t" || value.last == "\t"
+        if hasEdgeWhitespace
+            || value.contains(",") || value.contains("\"")
+            || value.contains("\n") || value.contains("\r") {
+            return "\"" + value.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+        }
+        return value
     }
 
     // MARK: - CSV parsing (RFC 4180)

--- a/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
+++ b/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
@@ -55,6 +55,7 @@ public struct DocumentConverterRegistry: Sendable {
             .registering(EPUBConverter(), priority: Priority.specific)
             .registering(WordConverter(), priority: Priority.specific)
             .registering(RTFConverter(), priority: Priority.specific)
+            .registering(CSVConverter(), priority: Priority.specific)
         #if canImport(PDFKit)
         registry = registry.registering(PDFConverter(), priority: Priority.specific)
         #endif

--- a/Sources/PicoDocs/Converters/PlainTextConverter.swift
+++ b/Sources/PicoDocs/Converters/PlainTextConverter.swift
@@ -4,8 +4,9 @@
 //
 //  Generic fallback converter. Decodes the input as text and emits it as a
 //  single Markdown body section. Registered at generic priority so it only runs
-//  after more specific converters decline. (Structure-aware CSV/JSON/XML
-//  converters arrive in later phases; for now they fall through to here.)
+//  after more specific converters decline. (CSV has its own structure-aware
+//  CSVConverter; a structured JSON/XML converter may follow — for now those fall
+//  through to here as text.)
 //
 
 import Foundation
@@ -16,7 +17,7 @@ public struct PlainTextConverter: DocumentConverter {
 
     public func accepts(_ info: StreamInfo) -> Bool {
         switch info.detectedFormat {
-        case .plainText, .csv, .json, .xml:
+        case .plainText, .json, .xml:
             return true
         default:
             // Only accept formats positively identified as text. In particular

--- a/Sources/PicoDocs/Renderers/DocumentRenderer.swift
+++ b/Sources/PicoDocs/Renderers/DocumentRenderer.swift
@@ -160,12 +160,27 @@ public enum DocumentRenderer {
 
     // MARK: - CSV
 
-    /// Emits CSV from the document's Markdown: pipe-table rows become CSV rows,
-    /// and any other non-blank line becomes a single-field row, so spreadsheet
-    /// exports are clean and prose isn't silently dropped.
+    /// Emits CSV from the document. A section that carries a lossless CSV
+    /// serialization in `metadata["csv"]` (e.g. `CSVConverter`, whose Markdown
+    /// table can't hold embedded newlines/whitespace) is emitted verbatim;
+    /// otherwise pipe-table rows become CSV rows and any other non-blank line
+    /// becomes a single-field row, so prose isn't silently dropped.
     private static func renderCSV(_ result: ConverterResult) -> String {
+        var parts: [String] = []
+        for section in result.sections where section.kind != .image {
+            if let rawCSV = section.metadata["csv"], !rawCSV.isEmpty {
+                parts.append(rawCSV)
+            } else {
+                let rows = csvRows(fromMarkdown: section.markdown)
+                if !rows.isEmpty { parts.append(rows.joined(separator: "\n")) }
+            }
+        }
+        return parts.joined(separator: "\n")
+    }
+
+    private static func csvRows(fromMarkdown markdown: String) -> [String] {
         var rows: [String] = []
-        let lines = result.markdown().components(separatedBy: "\n")
+        let lines = markdown.components(separatedBy: "\n")
         var i = 0
         var inCodeFence = false
         while i < lines.count {
@@ -200,7 +215,7 @@ public enum DocumentRenderer {
                 i += 1
             }
         }
-        return rows.joined(separator: "\n")
+        return rows
     }
 
     // MARK: - Markdown block parsing

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -76,6 +76,15 @@ struct ConverterTests {
         #expect(roundTrip.contains("\"Bob, Jr\",7"))
     }
 
+    @Test("CSV round-trip preserves quoted whitespace and embedded newlines")
+    func csvRoundTripFidelity() async throws {
+        let csv = "Name,Note\nAlice,\"hello\nworld\"\nBob,\" 007 \""
+        let result = try await PicoDocsEngine.convert(data: Data(csv.utf8), filename: "d.csv")
+        let out = try DocumentRenderer.render(result, to: .csv)
+        #expect(out.contains("\"hello\nworld\""))   // embedded newline preserved
+        #expect(out.contains("\" 007 \""))           // quoted leading/trailing spaces preserved
+    }
+
     @Test("EPUB converts spine chapters and reads metadata")
     func epub() async throws {
         let result = try await PicoDocsEngine.convert(data: Fixture.data("sample", "epub"), filename: "sample.epub")

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -63,6 +63,19 @@ struct ConverterTests {
         #expect(md.contains("Alice"))
     }
 
+    @Test("CSV converts to a Markdown table and round-trips back to CSV")
+    func csvInput() async throws {
+        let csv = "Name,Score\nAlice,42\n\"Bob, Jr\",7"
+        let result = try await PicoDocsEngine.convert(data: Data(csv.utf8), filename: "data.csv")
+        let md = result.markdown()
+        #expect(md.contains("| Name | Score |"))
+        #expect(md.contains("| Alice | 42 |"))
+        #expect(md.contains("| Bob, Jr | 7 |"))   // comma inside a quoted field stays one cell
+        let roundTrip = try DocumentRenderer.render(result, to: .csv)
+        #expect(roundTrip.contains("Name,Score"))
+        #expect(roundTrip.contains("\"Bob, Jr\",7"))
+    }
+
     @Test("EPUB converts spine chapters and reads metadata")
     func epub() async throws {
         let result = try await PicoDocsEngine.convert(data: Fixture.data("sample", "epub"), filename: "sample.epub")

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -85,6 +85,13 @@ struct ConverterTests {
         #expect(out.contains("\" 007 \""))           // quoted leading/trailing spaces preserved
     }
 
+    @Test("CSV parser keeps a final quoted empty record")
+    func csvFinalEmptyRecord() {
+        let rows = CSVConverter.parseCSV("value\n\"\"")
+        #expect(rows.count == 2)
+        #expect(rows.last == [""])
+    }
+
     @Test("EPUB converts spine chapters and reads metadata")
     func epub() async throws {
         let result = try await PicoDocsEngine.convert(data: Fixture.data("sample", "epub"), filename: "sample.epub")


### PR DESCRIPTION
## Phase 6a — CSVConverter (deferred follow-up)

CSV was handled by the generic `PlainTextConverter`, which emitted raw comma lines. Those rendered poorly (the CSV exporter collapsed each line into one quoted field; HTML/plaintext didn't tabulate) and weren't useful as Markdown for RAG.

Adds a dedicated **`CSVConverter`** (registered at `.specific` for `.csv`) that parses RFC 4180 CSV — quoted fields, escaped `""` quotes, embedded commas/newlines, CRLF/LF — into a Markdown table (pipes escaped, cell newlines flattened), mirroring the spreadsheet converter's table shape. `PlainTextConverter` no longer claims `.csv` (still handles plainText/json/xml).

A CSV file now converts to a real table across **all** export formats and **round-trips** back through the CSV renderer. Test covers input → table → CSV round-trip (including a comma inside a quoted field).

First of the deferred follow-ups. (The plaintext-Markdown-escaping sub-item is lower value and would need backslash-escape support in the renderers, so it's intentionally not bundled here.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP)_