### PR TITLE
Escape backslashes in Markdown table cells (round-trip fidelity)

### DIFF
--- a/Sources/PicoDocs/Converters/CSVConverter.swift
+++ b/Sources/PicoDocs/Converters/CSVConverter.swift
@@ -138,8 +138,7 @@ public struct CSVConverter: DocumentConverter {
         guard columnCount > 0 else { return "" }
 
         func cell(_ value: String) -> String {
-            value
-                .replacingOccurrences(of: "|", with: "\\|")
+            MarkdownTableCell.escapeDelimiters(value)
                 .replacingOccurrences(of: "\r\n", with: " ")
                 .replacingOccurrences(of: "\r", with: " ")
                 .replacingOccurrences(of: "\n", with: " ")

--- a/Sources/PicoDocs/Converters/HTML/HTMLToMarkdown.swift
+++ b/Sources/PicoDocs/Converters/HTML/HTMLToMarkdown.swift
@@ -178,9 +178,9 @@ enum HTMLToMarkdown {
                 // cells can't contain newlines) and escape pipes.
                 var rendered = ""
                 renderChildren(of: cell, into: &rendered)
-                return collapseWhitespace(rendered)
-                    .trimmingCharacters(in: .whitespaces)
-                    .replacingOccurrences(of: "|", with: "\\|")
+                return MarkdownTableCell.escapeDelimiters(
+                    collapseWhitespace(rendered).trimmingCharacters(in: .whitespaces)
+                )
             })
         }
         guard !rows.isEmpty else { return "" }

--- a/Sources/PicoDocs/Converters/SpreadsheetConverter.swift
+++ b/Sources/PicoDocs/Converters/SpreadsheetConverter.swift
@@ -88,8 +88,7 @@ public struct SpreadsheetConverter: DocumentConverter {
         }
         // Markdown table cells are single-line; escape pipes and flatten newlines
         // (including Windows CRLF and bare CR, common in Excel-on-Windows files).
-        return raw
-            .replacingOccurrences(of: "|", with: "\\|")
+        return MarkdownTableCell.escapeDelimiters(raw)
             .replacingOccurrences(of: "\r\n", with: " ")
             .replacingOccurrences(of: "\r", with: " ")
             .replacingOccurrences(of: "\n", with: " ")

--- a/Sources/PicoDocs/Converters/WordConverter.swift
+++ b/Sources/PicoDocs/Converters/WordConverter.swift
@@ -45,11 +45,8 @@ public struct WordConverter: DocumentConverter {
         // ones as Markdown footnote definitions (the body carries `[^fnN]`/
         // `[^enN]` reference markers at their positions).
         //
-        // NOTE: these are CommonMark footnote markers in the canonical Markdown.
-        // The non-Markdown renderers (DocumentRenderer HTML/plaintext) don't
-        // render `[^id]` footnotes yet, so those exports show the literal markers
-        // — a deliberately deferred renderer follow-up; Markdown export, the
-        // canonical product, is correct.
+        // NOTE: these are CommonMark footnote markers in the canonical Markdown;
+        // DocumentRenderer also renders them for the HTML and plaintext exports.
         let notes = Self.parseNotes(archive)
         let definitions = Self.referencedNoteIDs(in: body).compactMap { id in
             notes[id].map { text in
@@ -355,9 +352,8 @@ public struct WordConverter: DocumentConverter {
                     let t = renderInline(paragraph, relationships: relationships).trimmingCharacters(in: .whitespaces)
                     if !t.isEmpty { cellText += (cellText.isEmpty ? "" : "\n") + t }
                 }
-                // Single-line Markdown cells: escape pipes; CR/LF become <br>.
-                cells.append(cellText
-                    .replacingOccurrences(of: "|", with: "\\|")
+                // Single-line Markdown cells: escape delimiters; CR/LF become <br>.
+                cells.append(MarkdownTableCell.escapeDelimiters(cellText)
                     .replacingOccurrences(of: "\r\n", with: "<br>")
                     .replacingOccurrences(of: "\r", with: "<br>")
                     .replacingOccurrences(of: "\n", with: "<br>"))

--- a/Sources/PicoDocs/Renderers/DocumentRenderer.swift
+++ b/Sources/PicoDocs/Renderers/DocumentRenderer.swift
@@ -388,7 +388,7 @@ public enum DocumentRenderer {
                 // (second row), so all-dash data rows elsewhere are preserved.
                 var rowIndex = 0
                 while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces).hasPrefix("|") {
-                    let cells = parseTableRow(lines[i]).map { unescapePipes($0) }
+                    let cells = parseTableRow(lines[i]).map { MarkdownTableCell.unescape($0) }
                     if !(rowIndex == 1 && isTableSeparatorRow(cells)) {
                         rows.append(cells.map { csvField($0) }.joined(separator: ","))
                     }
@@ -451,7 +451,7 @@ public enum DocumentRenderer {
                 var rows: [[String]] = []
                 var rowIndex = 0
                 while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces).hasPrefix("|") {
-                    let cells = parseTableRow(lines[i]).map { unescapePipes($0) }
+                    let cells = parseTableRow(lines[i]).map { MarkdownTableCell.unescape($0) }
                     // The header/body separator is conventionally the second row;
                     // only drop an all-dash row there, so real data rows that
                     // happen to be all dashes elsewhere are kept.
@@ -550,18 +550,21 @@ public enum DocumentRenderer {
         var cells = line.trimmingCharacters(in: .whitespaces)
         if cells.hasPrefix("|") { cells.removeFirst() }
         if cells.hasSuffix("|") { cells.removeLast() }
-        // Split on unescaped pipes only.
+        // Split on unescaped pipes only; a backslash escapes the next character,
+        // so `\|` stays in the cell while `\\|` is a literal backslash + delimiter.
         var result: [String] = []
         var current = ""
-        var previous: Character?
+        var escaped = false
         for character in cells {
-            if character == "|", previous != "\\" {
-                result.append(current.trimmingCharacters(in: .whitespaces))
-                current = ""
+            if escaped {
+                current.append(character); escaped = false
+            } else if character == "\\" {
+                current.append(character); escaped = true
+            } else if character == "|" {
+                result.append(current.trimmingCharacters(in: .whitespaces)); current = ""
             } else {
                 current.append(character)
             }
-            previous = character
         }
         result.append(current.trimmingCharacters(in: .whitespaces))
         return result
@@ -575,9 +578,6 @@ public enum DocumentRenderer {
         }
     }
 
-    private static func unescapePipes(_ s: String) -> String {
-        s.replacingOccurrences(of: "\\|", with: "|")
-    }
 
     // MARK: - Inline rendering
 

--- a/Sources/PicoDocs/Renderers/DocumentRenderer.swift
+++ b/Sources/PicoDocs/Renderers/DocumentRenderer.swift
@@ -549,7 +549,13 @@ public enum DocumentRenderer {
     private static func parseTableRow(_ line: String) -> [String] {
         var cells = line.trimmingCharacters(in: .whitespaces)
         if cells.hasPrefix("|") { cells.removeFirst() }
-        if cells.hasSuffix("|") { cells.removeLast() }
+        if cells.hasSuffix("|") {
+            // Strip the trailing delimiter only if the pipe is unescaped (an even
+            // number of backslashes precede it); otherwise it's a literal `\|` in
+            // a row that omits the closing delimiter.
+            let backslashes = cells.dropLast().reversed().prefix { $0 == "\\" }.count
+            if backslashes.isMultiple(of: 2) { cells.removeLast() }
+        }
         // Split on unescaped pipes only; a backslash escapes the next character,
         // so `\|` stays in the cell while `\\|` is a literal backslash + delimiter.
         var result: [String] = []

--- a/Sources/PicoDocs/Renderers/MarkdownTableCell.swift
+++ b/Sources/PicoDocs/Renderers/MarkdownTableCell.swift
@@ -1,0 +1,44 @@
+//
+//  MarkdownTableCell.swift
+//  PicoDocs
+//
+//  Escaping/unescaping for pipe-table cell values, shared by the converters that
+//  produce Markdown tables (Word, spreadsheet, CSV, HTML) and the renderer that
+//  re-parses them, so cell values round-trip. Both the backslash and the pipe
+//  delimiter are structural, so backslash is escaped first and the pipe second
+//  (and unescaped in the same order), letting a literal `\` or `|` survive.
+//
+
+import Foundation
+
+enum MarkdownTableCell {
+
+    /// Escapes the characters that are structural in a pipe-table cell: a literal
+    /// backslash (`\` -> `\\`, done first) and the pipe delimiter (`|` -> `\|`).
+    /// Newlines are handled separately by callers (some join with spaces, some
+    /// with `<br>`).
+    static func escapeDelimiters(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "|", with: "\\|")
+    }
+
+    /// Inverse of `escapeDelimiters`: turns `\\` back into `\` and `\|` into `|`,
+    /// leaving any other backslash sequence untouched (so a stray `\x` from a
+    /// non-escaping source isn't corrupted).
+    static func unescape(_ value: String) -> String {
+        var result = ""
+        var index = value.startIndex
+        while index < value.endIndex {
+            let next = value.index(after: index)
+            if value[index] == "\\", next < value.endIndex, value[next] == "\\" || value[next] == "|" {
+                result.append(value[next])
+                index = value.index(after: next)
+            } else {
+                result.append(value[index])
+                index = next
+            }
+        }
+        return result
+    }
+}

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -186,6 +186,15 @@ struct ConverterTests {
         #expect(rows.last == [""])
     }
 
+    @Test("CSV cell with a backslash and a pipe round-trips through the Markdown table")
+    func csvBackslashPipeCell() async throws {
+        let csv = "Col\na\\b|c"   // value: a\b|c (backslash, then a literal pipe)
+        let result = try await PicoDocsEngine.convert(data: Data(csv.utf8), filename: "t.csv")
+        #expect(result.markdown().contains("a\\\\b\\|c"))   // escaped in the table as a\\b\|c
+        let text = try DocumentRenderer.render(result, to: .plaintext)
+        #expect(text.contains("a\\b|c"))                     // unescaped back to a\b|c
+    }
+
     @Test("EPUB converts spine chapters and reads metadata")
     func epub() async throws {
         let result = try await PicoDocsEngine.convert(data: Fixture.data("sample", "epub"), filename: "sample.epub")
@@ -352,6 +361,19 @@ struct DocumentRendererTests {
         let html = try DocumentRenderer.render(result, to: .html)
         #expect(!html.contains("a\" onmouseover=\"alert"))   // the raw quote cannot close href
         #expect(html.contains("&quot;"))
+    }
+
+    @Test("Table cells round-trip backslashes and escaped pipes")
+    func tableCellBackslashEscaping() throws {
+        // Cell value `a\b|c`, escaped in the table as `a\\b\|c`.
+        let result = ConverterResult(sections: [
+            DocumentSection(kind: .body, markdown: "| K | V |\n| --- | --- |\n| key | a\\\\b\\|c |"),
+        ])
+        // Plaintext re-parses the table: `\\` -> `\`, `\|` -> `|`, and the escaped
+        // pipe does not split the cell.
+        #expect(try DocumentRenderer.render(result, to: .plaintext).contains("a\\b|c"))
+        // HTML keeps the literal backslash and pipe in the cell.
+        #expect(try DocumentRenderer.render(result, to: .html).contains("<td>a\\b|c</td>"))
     }
 
     @Test("Footnote references inside code spans are not rewritten (HTML)")

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -376,6 +376,15 @@ struct DocumentRendererTests {
         #expect(try DocumentRenderer.render(result, to: .html).contains("<td>a\\b|c</td>"))
     }
 
+    @Test("Table row without a closing delimiter keeps a trailing escaped pipe")
+    func tableCellTrailingEscapedPipe() throws {
+        let result = ConverterResult(sections: [
+            DocumentSection(kind: .body, markdown: "| K | V |\n| --- | --- |\n| key | a\\|"),
+        ])
+        // The trailing `\|` is a literal pipe, not the (absent) closing delimiter.
+        #expect(try DocumentRenderer.render(result, to: .plaintext).contains("key\ta|"))
+    }
+
     @Test("Footnote references inside code spans are not rewritten (HTML)")
     func footnoteCodeSpanHTML() throws {
         let result = ConverterResult(sections: [


### PR DESCRIPTION
## Summary

Markdown table cells escaped only the pipe delimiter, not the backslash, so a literal `\` in a cell could corrupt round-trips. For example a cell value `a\b|c` was emitted as `a\\b|c` (backslash left unescaped); re-parsing then read `\\` as an escaped backslash and the following `|` as a real delimiter, splitting the cell.

Centralizes cell escaping in a new shared `MarkdownTableCell` helper, used by all four table producers (`WordConverter`, `SpreadsheetConverter`, `CSVConverter`, `HTMLToMarkdown`) and the renderer:
- `escapeDelimiters` escapes backslash first (`\`→`\\`) then the pipe (`|`→`\|`);
- `unescape` reverses both (and leaves an unrelated `\x` untouched);
- `parseTableRow` now splits with proper backslash-escape awareness, so `\|` stays in the cell while `\\|` is a literal backslash + a delimiter.

Drive-by: corrects a comment in `WordConverter` left stale by #21 (the HTML/plaintext renderers do now render footnotes).

## Tests
- `csvBackslashPipeCell`: a CSV value `a\b|c` is escaped as `a\\b\|c` in the table and round-trips back to `a\b|c` via plaintext export.
- `tableCellBackslashEscaping`: a table whose cell is `a\\b\|c` unescapes to `a\b|c` in both plaintext and HTML (no split on the escaped pipe).

https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP)_