### PR TITLE
Image-embed collision guard and multibyte (DBCS) RTF decoding

### DIFF
--- a/Sources/PicoDocs/Converters/PlainTextConverter.swift
+++ b/Sources/PicoDocs/Converters/PlainTextConverter.swift
@@ -40,6 +40,11 @@ public struct PlainTextConverter: DocumentConverter {
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw PicoDocsError.emptyDocument
         }
+        // NOTE: the decoded text is stored verbatim as the Markdown body, so any
+        // Markdown metacharacters it contains (`*`, `#`, `|`, …) are interpreted
+        // by the renderers on non-Markdown export. Markdown-escaping this is
+        // deliberately deferred (see DocumentRenderer's header) — the likely fix
+        // is adopting swift-markdown for real CommonMark handling.
         let section = DocumentSection(title: info.filename, kind: .body, markdown: text)
         return ConverterResult(title: info.filename, sections: [section])
     }

--- a/Sources/PicoDocs/Converters/RTFConverter.swift
+++ b/Sources/PicoDocs/Converters/RTFConverter.swift
@@ -65,8 +65,12 @@ public struct RTFConverter: DocumentConverter {
         var ignore = false
         var ucSkip = 1
         var ansiEncoding: String.Encoding = .windowsCP1252
+        var isDBCS = false
         var stack: [GroupState] = []
         var pendingHighSurrogate: Int?
+        // Bytes from consecutive `\'hh` escapes, buffered so a multibyte (DBCS)
+        // character split across escapes is decoded as one unit (see flushBytes).
+        var pendingBytes: [UInt8] = []
 
         var runs: [Run] = []
         var paragraphs: [String] = []
@@ -81,6 +85,15 @@ public struct RTFConverter: DocumentConverter {
             }
         }
 
+        // Decode any buffered `\'hh` bytes as a group (so a multibyte DBCS
+        // character spanning consecutive escapes survives) and append the result.
+        func flushBytes() {
+            guard !pendingBytes.isEmpty else { return }
+            let decoded = Self.decodeBytes(pendingBytes, encoding: ansiEncoding)
+            pendingBytes.removeAll(keepingCapacity: true)
+            appendText(decoded)
+        }
+
         func flushParagraph() {
             let rendered = runs.map { renderRun($0) }.joined()
             runs.removeAll(keepingCapacity: true)
@@ -90,6 +103,11 @@ public struct RTFConverter: DocumentConverter {
 
         while i < n {
             let c = chars[i]
+            // Consecutive `\'hh` escapes form one (possibly multibyte) character;
+            // flush the buffer before any other token so byte order is preserved.
+            if !pendingBytes.isEmpty, !(c == "\\" && i + 1 < n && chars[i + 1] == "'") {
+                flushBytes()
+            }
             switch c {
             case "{":
                 stack.append(GroupState(bold: bold, italic: italic, ignore: ignore, ucSkip: ucSkip))
@@ -132,7 +150,10 @@ public struct RTFConverter: DocumentConverter {
                     case "rdblquote": appendText("\u{201D}")
                     case "emspace", "enspace", "qmspace": appendText(" ")
                     case "ansicpg":
-                        if let param, let encoding = Self.encoding(forCodepage: param) { ansiEncoding = encoding }
+                        if let param, let encoding = Self.encoding(forCodepage: param) {
+                            ansiEncoding = encoding
+                            isDBCS = Self.dbcsCodepages.contains(param)
+                        }
                     case "bin":
                         // \binN: the next N bytes are raw binary (often inside an
                         // ignored \pict/\object) and may contain { } or \ — skip
@@ -211,7 +232,14 @@ public struct RTFConverter: DocumentConverter {
                     case "*": ignore = true                    // ignorable destination
                     case "'":
                         if i + 1 < n, let byte = UInt8(String([chars[i], chars[i + 1]]), radix: 16) {
-                            appendText(Self.decodeByte(byte, encoding: ansiEncoding))
+                            // DBCS code pages: buffer the byte (a lead byte alone is
+                            // undecodable) and let flushBytes decode whole characters.
+                            // Single-byte code pages decode each byte on its own.
+                            if isDBCS {
+                                if !ignore { pendingBytes.append(byte) }
+                            } else {
+                                appendText(Self.decodeByte(byte, encoding: ansiEncoding))
+                            }
                             i += 2
                         }
                     case "\n", "\r":
@@ -228,8 +256,26 @@ public struct RTFConverter: DocumentConverter {
                 i += 1
             }
         }
+        flushBytes()
         flushParagraph()
         return paragraphs.joined(separator: "\n\n")
+    }
+
+    /// Windows code pages that are double-byte (DBCS): one character may span two
+    /// consecutive `\'hh` escapes, so their bytes are buffered and group-decoded
+    /// (`decodeBytes`) rather than decoded one byte at a time. 932 Shift-JIS, 936
+    /// GBK, 949 UHC, 950 Big5, 1361 Johab.
+    private static let dbcsCodepages: Set<Int> = [932, 936, 949, 950, 1361]
+
+    /// Decodes a run of buffered `\'hh` bytes as a single unit using the declared
+    /// code page — required for DBCS code pages, where a lead byte is undecodable
+    /// on its own. Falls back to byte-by-byte decoding for an invalid or partial
+    /// multibyte sequence so nothing is lost.
+    private static func decodeBytes(_ bytes: [UInt8], encoding: String.Encoding) -> String {
+        if let decoded = String(bytes: bytes, encoding: encoding), !decoded.isEmpty {
+            return decoded
+        }
+        return bytes.map { decodeByte($0, encoding: encoding) }.joined()
     }
 
     /// Decodes a single `\'hh` byte using the document's declared code page
@@ -237,10 +283,10 @@ public struct RTFConverter: DocumentConverter {
     /// become the right punctuation/letters rather than C1 control characters.
     /// Falls back to Windows-1252, then Latin-1, for undecodable bytes.
     ///
-    /// Each `\'hh` is decoded on its own. Multibyte ANSI code pages (e.g. 932
-    /// Shift-JIS) that split one character across consecutive `\'hh` escapes are
-    /// not reassembled here — a deliberately deferred legacy niche, since modern
-    /// RTF emits non-ASCII (including CJK) as `\uN`, which is handled in full.
+    /// Used for single-byte code pages; DBCS code pages declared via `\ansicpg`
+    /// (Shift-JIS, GBK, Big5, …) are reassembled across escapes by `decodeBytes`.
+    /// A document that switches code page per font via `\fcharsN` alone (without
+    /// `\ansicpg`) is still a deferred niche — the font table isn't tracked.
     private static func decodeByte(_ byte: UInt8, encoding: String.Encoding) -> String {
         if let decoded = String(bytes: [byte], encoding: encoding), !decoded.isEmpty {
             return decoded

--- a/Sources/PicoDocs/Converters/RTFConverter.swift
+++ b/Sources/PicoDocs/Converters/RTFConverter.swift
@@ -56,7 +56,11 @@ public struct RTFConverter: DocumentConverter {
     ]
 
     static func markdown(fromRTF rtf: String) -> String {
-        let chars = Array(rtf)
+        // Normalize CRLF line wraps to a single LF first: Swift treats "\r\n" as
+        // one grapheme cluster, so it would match neither the per-character "\r"
+        // nor "\n" handling below — it would leak into the output as content and
+        // could fall *inside* a buffered DBCS sequence, splitting the character.
+        let chars = Array(rtf.replacingOccurrences(of: "\r\n", with: "\n"))
         let n = chars.count
         var i = 0
 

--- a/Sources/PicoDocs/Converters/RTFConverter.swift
+++ b/Sources/PicoDocs/Converters/RTFConverter.swift
@@ -56,11 +56,11 @@ public struct RTFConverter: DocumentConverter {
     ]
 
     static func markdown(fromRTF rtf: String) -> String {
-        // Normalize CRLF line wraps to a single LF first: Swift treats "\r\n" as
-        // one grapheme cluster, so it would match neither the per-character "\r"
-        // nor "\n" handling below — it would leak into the output as content and
-        // could fall *inside* a buffered DBCS sequence, splitting the character.
-        let chars = Array(rtf.replacingOccurrences(of: "\r\n", with: "\n"))
+        // NOTE: Swift clusters "\r\n" into a single Character, so the newline
+        // handling below matches it as one grapheme (alongside lone "\r"/"\n")
+        // rather than normalizing the string — which keeps `\bin` byte-offset
+        // skipping (which indexes this array) untouched.
+        let chars = Array(rtf)
         let n = chars.count
         var i = 0
 
@@ -111,9 +111,10 @@ public struct RTFConverter: DocumentConverter {
             // flush the buffer before any other token so byte order is preserved.
             // Raw newlines are non-content (RTF line-wrapping) and can fall *inside*
             // a DBCS character (\'82\r\n\'a0), so they must not flush the buffer.
+            // "\r\n" is matched explicitly because Swift treats it as one Character.
             if !pendingBytes.isEmpty,
                !(c == "\\" && i + 1 < n && chars[i + 1] == "'"),
-               c != "\r", c != "\n" {
+               c != "\r", c != "\n", c != "\r\n" {
                 flushBytes()
             }
             switch c {
@@ -250,14 +251,14 @@ public struct RTFConverter: DocumentConverter {
                             }
                             i += 2
                         }
-                    case "\n", "\r":
+                    case "\n", "\r", "\r\n":
                         if !ignore { flushParagraph() }        // escaped newline = \par
                     default: break
                     }
                 }
 
-            case "\r", "\n":
-                i += 1                                          // raw newlines aren't content
+            case "\r", "\n", "\r\n":
+                i += 1                                          // raw newlines aren't content (CRLF is one grapheme)
 
             default:
                 appendText(String(c))
@@ -275,15 +276,35 @@ public struct RTFConverter: DocumentConverter {
     /// GBK, 949 UHC, 950 Big5, 1361 Johab.
     private static let dbcsCodepages: Set<Int> = [932, 936, 949, 950, 1361]
 
-    /// Decodes a run of buffered `\'hh` bytes as a single unit using the declared
-    /// code page — required for DBCS code pages, where a lead byte is undecodable
-    /// on its own. Falls back to byte-by-byte decoding for an invalid or partial
-    /// multibyte sequence so nothing is lost.
+    /// Decodes a run of buffered `\'hh` bytes using the declared code page —
+    /// required for DBCS code pages, where a lead byte is undecodable on its own.
+    ///
+    /// If the whole run decodes, return it. Otherwise walk it greedily, taking the
+    /// longest valid unit at each step (a two-byte lead+trail pair, else a single
+    /// byte), so a malformed or partial byte only affects itself and not the valid
+    /// characters around it — one bad byte can't corrupt a whole run of CJK. The
+    /// offending byte still falls back to Windows-1252/Latin-1 so nothing is lost.
     private static func decodeBytes(_ bytes: [UInt8], encoding: String.Encoding) -> String {
         if let decoded = String(bytes: bytes, encoding: encoding), !decoded.isEmpty {
             return decoded
         }
-        return bytes.map { decodeByte($0, encoding: encoding) }.joined()
+        var result = ""
+        var idx = 0
+        let count = bytes.count
+        while idx < count {
+            if idx + 1 < count,
+               let pair = String(bytes: bytes[idx...(idx + 1)], encoding: encoding), !pair.isEmpty {
+                result += pair
+                idx += 2
+            } else if let single = String(bytes: bytes[idx...idx], encoding: encoding), !single.isEmpty {
+                result += single
+                idx += 1
+            } else {
+                result += decodeByte(bytes[idx], encoding: encoding)
+                idx += 1
+            }
+        }
+        return result
     }
 
     /// Decodes a single `\'hh` byte using the document's declared code page

--- a/Sources/PicoDocs/Converters/RTFConverter.swift
+++ b/Sources/PicoDocs/Converters/RTFConverter.swift
@@ -105,7 +105,11 @@ public struct RTFConverter: DocumentConverter {
             let c = chars[i]
             // Consecutive `\'hh` escapes form one (possibly multibyte) character;
             // flush the buffer before any other token so byte order is preserved.
-            if !pendingBytes.isEmpty, !(c == "\\" && i + 1 < n && chars[i + 1] == "'") {
+            // Raw newlines are non-content (RTF line-wrapping) and can fall *inside*
+            // a DBCS character (\'82\r\n\'a0), so they must not flush the buffer.
+            if !pendingBytes.isEmpty,
+               !(c == "\\" && i + 1 < n && chars[i + 1] == "'"),
+               c != "\r", c != "\n" {
                 flushBytes()
             }
             switch c {

--- a/Sources/PicoDocs/Converters/WordConverter.swift
+++ b/Sources/PicoDocs/Converters/WordConverter.swift
@@ -69,9 +69,12 @@ public struct WordConverter: DocumentConverter {
         // archive path). NOTE: image identity downstream (the inline `src` and the
         // renderer's data-URL embedding) is keyed by basename, so two *different*
         // images that share a basename would collide — only possible when a note
-        // part lives in its own subfolder with its own media. Unique/path-aware
-        // image names are a deferred cross-cutting follow-up; standard DOCX layouts
-        // (all media under `word/media/` with unique names) are unaffected.
+        // part lives in its own subfolder with its own media. The renderer detects
+        // that collision and leaves the ref unresolved rather than embedding the
+        // wrong image (see DocumentRenderer.embedImageDataURLs); giving each image
+        // a clean, unique/path-aware name so both still render is a deferred
+        // cross-cutting follow-up. Standard DOCX layouts (all media under
+        // `word/media/` with unique names) are unaffected.
         var seenImagePaths = Set<String>()
         imageSections = imageSections.filter { section in
             guard let path = section.sourcePath else { return true }

--- a/Sources/PicoDocs/Renderers/DocumentRenderer.swift
+++ b/Sources/PicoDocs/Renderers/DocumentRenderer.swift
@@ -11,11 +11,13 @@
 //  pipe tables, rules) rather than implementing a full CommonMark parser.
 //
 //  These renderers assume their input is the canonical Markdown the converters
-//  emit. Raw-text and CSV *inputs* are currently stored verbatim by
-//  PlainTextConverter (it doesn't Markdown-escape text or parse CSV into a
-//  table), so re-exporting those specific inputs to plaintext/CSV can drop a
-//  literal `*` or collapse columns — making those round-trips lossless is a
-//  PlainTextConverter follow-up, not a renderer change.
+//  emit. Raw-text *inputs* are currently stored verbatim by PlainTextConverter
+//  (it doesn't Markdown-escape text), so re-exporting that specific input to
+//  plaintext can drop a literal `*` and the like. Fixing this well needs either
+//  CommonMark backslash-escape support in this hand-rolled parser (risky) or a
+//  verbatim-fence in PlainTextConverter (regresses prose); both are deliberately
+//  deferred. The cleaner long-term fix is likely to replace this Markdown subset
+//  parser with swift-markdown (a real CommonMark parser/renderer) — revisit then.
 //
 
 import Foundation
@@ -137,11 +139,27 @@ public enum DocumentRenderer {
 
     /// Replaces bare image `src="filename"` references with `data:` URLs built
     /// from the `.image` sections' base64/MIME metadata.
+    ///
+    /// The body refers to images by basename, so two *distinct* images that share
+    /// a basename (only possible with non-standard layouts — e.g. a DOCX note part
+    /// carrying its own media folder) are indistinguishable in the body HTML.
+    /// Embedding either would silently show the wrong image, so such references are
+    /// left unresolved (an honest broken ref) rather than confidently wrong. Giving
+    /// every image a clean, unique/path-aware name would need generation-time
+    /// threading through the converters — a deferred follow-up; standard documents
+    /// (unique media names) embed exactly as before.
     private static func embedImageDataURLs(_ html: String, sections: [DocumentSection]) -> String {
+        let imageSections = sections.filter { $0.kind == .image }
+        // Count basenames among *embeddable* sections; a basename shared by two of
+        // them is ambiguous and skipped below.
+        var basenameCounts: [String: Int] = [:]
+        for section in imageSections where !(section.metadata["base64"] ?? "").isEmpty {
+            guard let filename = imageRefName(for: section) else { continue }
+            basenameCounts[filename, default: 0] += 1
+        }
         var result = html
-        for section in sections where section.kind == .image {
-            let filename = (section.sourcePath as NSString?)?.lastPathComponent ?? section.title
-            guard let filename, !filename.isEmpty,
+        for section in imageSections {
+            guard let filename = imageRefName(for: section), basenameCounts[filename] == 1,
                   let base64 = section.metadata["base64"], !base64.isEmpty else { continue }
             let mime = section.metadata["mimeType"] ?? "application/octet-stream"
             result = result.replacingOccurrences(
@@ -150,6 +168,14 @@ public enum DocumentRenderer {
             )
         }
         return result
+    }
+
+    /// The basename a `.image` section is referenced by in the body Markdown:
+    /// its source path's last component, falling back to its title.
+    private static func imageRefName(for section: DocumentSection) -> String? {
+        let filename = (section.sourcePath as NSString?)?.lastPathComponent ?? section.title
+        guard let filename, !filename.isEmpty else { return nil }
+        return filename
     }
 
     private static func renderHTMLTable(_ rows: [[String]], footnoteNumbers: [String: Int] = [:]) -> String {

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -265,6 +265,17 @@ struct ConverterTests {
         #expect(md.contains("\u{2014}"))
     }
 
+    @Test("RTF reassembles multibyte DBCS \\'hh escapes (Shift-JIS) into characters")
+    func rtfDBCSShiftJIS() async throws {
+        // \ansicpg932 = Shift-JIS, a double-byte code page. Each CJK character is
+        // two consecutive \'hh escapes: あ = 0x82 0xA0, 日 = 0x93 0xFA,
+        // 本 = 0x96 0x7B. Decoded one byte at a time these would be mojibake.
+        let rtf = "{\\rtf1\\ansi\\ansicpg932 \\'82\\'a0\\'93\\'fa\\'96\\'7b done.\\par}"
+        let md = try await PicoDocsEngine.convert(data: Data(rtf.utf8), filename: "jp.rtf").markdown()
+        #expect(md.contains("\u{3042}\u{65E5}\u{672C}"))   // あ日本
+        #expect(md.contains("done."))
+    }
+
     @Test("RTF combines \\uN surrogate pairs into astral characters")
     func rtfSurrogatePair() async throws {
         // U+1F600 as a UTF-16 surrogate pair (\uc0 means no fallback bytes).

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -135,6 +135,36 @@ struct ConverterTests {
         #expect(!html.contains("src=\"image1.png\""))
     }
 
+    @Test("HTML embedding leaves basename-colliding images unresolved, embeds unique ones")
+    func htmlImageEmbedCollision() throws {
+        // Body refers to images by basename; two *distinct* images sharing a
+        // basename (e.g. body media + a note part's own media) are ambiguous in
+        // the body HTML, so neither is embedded (an honest broken ref beats a
+        // confidently wrong image). A uniquely-named image still embeds.
+        let body = DocumentSection(kind: .body, markdown: "![a](image1.png)\n\n![b](image2.png)")
+        let dupA = DocumentSection(
+            kind: .image, markdown: "![a](image1.png)", sourcePath: "word/media/image1.png",
+            metadata: ["mimeType": "image/png", "base64": "AAAA"]
+        )
+        let dupB = DocumentSection(
+            kind: .image, markdown: "![a](image1.png)", sourcePath: "word/notes/media/image1.png",
+            metadata: ["mimeType": "image/png", "base64": "BBBB"]
+        )
+        let unique = DocumentSection(
+            kind: .image, markdown: "![b](image2.png)", sourcePath: "word/media/image2.png",
+            metadata: ["mimeType": "image/png", "base64": "CCCC"]
+        )
+        let result = ConverterResult(title: "t", sections: [body, dupA, dupB, unique])
+        let html = try DocumentRenderer.render(result, to: .html)
+        // Ambiguous basename: neither image embedded, ref left unresolved.
+        #expect(!html.contains("base64,AAAA"))
+        #expect(!html.contains("base64,BBBB"))
+        #expect(html.contains("src=\"image1.png\""))
+        // Unique basename: embedded as a data URL.
+        #expect(html.contains("src=\"data:image/png;base64,CCCC\""))
+        #expect(!html.contains("src=\"image2.png\""))
+    }
+
     @Test("DOCX part-path resolution honors the owning part's base directory")
     func docxResolvePartPath() {
         // Body part / standard-location notes: targets are relative to `word`.

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -276,6 +276,17 @@ struct ConverterTests {
         #expect(md.contains("done."))
     }
 
+    @Test("RTF DBCS character split across a raw line-wrap newline stays intact")
+    func rtfDBCSAcrossNewline() async throws {
+        // RTF wraps long lines with raw CRLFs; a double-byte char can land across
+        // one (日 = 0x93 0xFA emitted as \'93 <CRLF> \'fa). The raw newline must
+        // not flush the byte buffer mid-character.
+        let rtf = "{\\rtf1\\ansi\\ansicpg932 \\'93\r\n\\'fa done.\\par}"
+        let md = try await PicoDocsEngine.convert(data: Data(rtf.utf8), filename: "jp.rtf").markdown()
+        #expect(md.contains("\u{65E5}"))   // 日
+        #expect(md.contains("done."))
+    }
+
     @Test("RTF combines \\uN surrogate pairs into astral characters")
     func rtfSurrogatePair() async throws {
         // U+1F600 as a UTF-16 surrogate pair (\uc0 means no fallback bytes).

--- a/Tests/PicoDocsTests/ConverterTests.swift
+++ b/Tests/PicoDocsTests/ConverterTests.swift
@@ -287,6 +287,17 @@ struct ConverterTests {
         #expect(md.contains("done."))
     }
 
+    @Test("RTF DBCS run keeps valid characters before a malformed trailing byte")
+    func rtfDBCSPartialTail() async throws {
+        // あ (0x82 0xA0) followed by a dangling lead byte 0x82: the whole run fails
+        // to decode, but the valid leading character must survive (the bad byte
+        // alone falls back) rather than corrupting the entire run.
+        let rtf = "{\\rtf1\\ansi\\ansicpg932 \\'82\\'a0\\'82 X\\par}"
+        let md = try await PicoDocsEngine.convert(data: Data(rtf.utf8), filename: "jp.rtf").markdown()
+        #expect(md.contains("\u{3042}"))   // あ preserved
+        #expect(md.contains("X"))
+    }
+
     @Test("RTF combines \\uN surrogate pairs into astral characters")
     func rtfSurrogatePair() async throws {
         // U+1F600 as a UTF-16 surrogate pair (\uc0 means no fallback bytes).


### PR DESCRIPTION
Two self-contained robustness fixes for converting non-standard / legacy documents, plus in-code notes recording deliberately-deferred follow-ups.

## Changes

### Guard HTML image embedding against basename collisions (`91d5442`)
Image references in body Markdown are keyed by basename, so two *distinct* images that share one (only possible with non-standard layouts — e.g. a DOCX note part carrying its own media folder) were indistinguishable in the body HTML, and the data-URL embedder would silently substitute the **wrong** image's bytes. The renderer now detects the ambiguous basename and leaves the reference unresolved (an honest broken ref) rather than embedding the wrong image. Standard documents with unique media names embed exactly as before. New test: `htmlImageEmbedCollision`.

### Reassemble multibyte (DBCS) RTF `\'hh` escapes (`a6ad463`)
Legacy CJK RTF in a double-byte code page (`\ansicpg932` Shift-JIS, 936 GBK, 949 UHC, 950 Big5, 1361 Johab) encodes each character as two consecutive `\'hh` escapes; decoding each byte on its own produced mojibake (a lead byte is undecodable alone and fell back to CP1252). The parser now buffers the bytes from consecutive `\'hh` escapes and group-decodes the run as one unit once a non-escape token follows. Single-byte code pages — the common case, including the default Windows-1252 — are unchanged (the buffer stays empty); an invalid/partial sequence degrades to byte-by-byte decoding so nothing is lost. New test: `rtfDBCSShiftJIS`.

## Deferred (documented in-code)
- **PlainText/source Markdown-escaping** — raw text is stored verbatim and so is interpreted as Markdown on non-Markdown export; a proper fix needs renderer-wide CommonMark backslash-escape support or a verbatim fence. Noted swift-markdown as the likely long-term direction.
- **Clean unique/path-aware image names** so collided images still render (needs generation-time threading through the converters).
- **Mixed image+text hyperlinks** — an image inside a linked label renders as escaped text (the URL, the text, and the image bytes are all still preserved); a proper fix needs a structured inline representation.

## Verification
Developed in an environment without a Swift toolchain, so these commits are unverified locally — this PR exists to run CI (macOS, Swift 6) over both changes and the two new tests.

https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPiUoXjbN1KLgYXsSE2cdP)_