### PR TITLE
Add on-device Vision OCR: scanned-PDF fallback + image converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ PicoDocs supports and processes a variety of document formats:
 - **File Types**: PDF, ePub, DOCX, XLSX, HTML, Markdown, and more.
 - **Export Options**: Convert documents to HTML, Markdown, and JSON formats for LLM compatibility, with embedded and referenced images.
 - **Content Cleanup**: Utilizes Readability to clean HTML content, enhancing focus on the main content similar to Safari's Reader View.
+- **OCR**: On-device text recognition (Apple Vision) for standalone images and scanned / image-only PDF pages — no model bundle or cloud service. Enabled by default; toggle with `enableOCR`.
 - **Multiple Sources**: Reads local files and iCloud files.
 
 ## How It Works
@@ -29,7 +30,7 @@ There are two main steps: fetching and parsing.
 
 ## Supported File Types
 
-- PDF
+- PDF (with on-device OCR fallback for scanned / image-only pages)
 - ePub
 - DOCX
 - HTML/XHTML
@@ -38,6 +39,7 @@ There are two main steps: fetching and parsing.
 - RTF
 - MD
 - Webloc
+- Images (PNG, JPEG, HEIC, …) via OCR
 
 ## Installation
 

--- a/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
+++ b/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
@@ -59,6 +59,11 @@ public struct DocumentConverterRegistry: Sendable {
         #if canImport(PDFKit)
         registry = registry.registering(PDFConverter(), priority: Priority.specific)
         #endif
+        #if canImport(Vision)
+        // Makes the detector's `.image` classification convertible via on-device
+        // OCR. Apple-platform only, so it's gated like the PDF converter.
+        registry = registry.registering(ImageOCRConverter(), priority: Priority.specific)
+        #endif
         return registry.registering(PlainTextConverter(), priority: Priority.generic)
     }
 

--- a/Sources/PicoDocs/Converters/OCR/ImageOCRConverter.swift
+++ b/Sources/PicoDocs/Converters/OCR/ImageOCRConverter.swift
@@ -12,6 +12,7 @@
 import Foundation
 import CoreGraphics
 import ImageIO
+import UniformTypeIdentifiers
 
 public struct ImageOCRConverter: DocumentConverter {
 
@@ -27,28 +28,55 @@ public struct ImageOCRConverter: DocumentConverter {
         // rather than as an empty success.
         guard info.enableOCR else { throw ConverterError.notAccepted }
 
+        // Multi-page TIFFs (e.g. scanner output) pack several pages into one file.
+        // Other image types — including animated GIF/PNG and multi-image HEIC —
+        // are treated as a single image (frame 0) so an animation doesn't emit a
+        // section per frame. (Reaching this converter means the detector matched
+        // `info.utType` to `.image`, so the concrete type is known here.)
+        let isMultiPage = info.utType?.conforms(to: .tiff) ?? false
+
         try Task.checkCancellation()
-        // Decode + OCR both run off the cooperative pool (see
-        // `runOffCooperativePool`); only `Data` in / `String` out crosses the
-        // boundary, so no non-Sendable `CGImage` escapes.
-        let text = try await VisionOCRService.runOffCooperativePool {
-            guard let image = Self.decodeBoundedImage(from: data) else {
+        // Decode + OCR run off the cooperative pool (see `runOffCooperativePool`);
+        // only `Data` in / `[String]` out crosses the boundary, so no non-Sendable
+        // `CGImage` escapes. One element per frame, in source order (may be "").
+        let frameTexts = try await VisionOCRService.runOffCooperativePool { () throws -> [String] in
+            guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
                 throw PicoDocsError.fileCorrupted
             }
-            return try VisionOCRService()
-                .recognizeText(in: image)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let frameCount = isMultiPage ? max(CGImageSourceGetCount(source), 1) : 1
+            let service = VisionOCRService()
+            return try (0..<frameCount).map { index in
+                guard let image = Self.boundedImage(from: source, at: index) else { return "" }
+                return try service.recognizeText(in: image)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
         }
 
-        guard !text.isEmpty else { throw PicoDocsError.emptyDocument }
+        guard frameTexts.contains(where: { !$0.isEmpty }) else {
+            throw PicoDocsError.emptyDocument
+        }
 
-        let section = DocumentSection(
-            title: info.filename,
-            kind: .body,
-            markdown: text,
-            metadata: ["extractionMethod": "vision-ocr"]
-        )
-        return ConverterResult(title: info.filename, sections: [section])
+        let sections: [DocumentSection]
+        if frameTexts.count == 1 {
+            sections = [DocumentSection(
+                title: info.filename,
+                kind: .body,
+                markdown: frameTexts[0],
+                metadata: ["extractionMethod": "vision-ocr"]
+            )]
+        } else {
+            // One section per non-empty frame, carrying its 1-based page index so
+            // multi-page sources stay individually addressable (like PDF pages).
+            sections = frameTexts.enumerated().compactMap { index, text in
+                text.isEmpty ? nil : DocumentSection(
+                    kind: .body,
+                    markdown: text,
+                    pageRange: (index + 1)...(index + 1),
+                    metadata: ["extractionMethod": "vision-ocr"]
+                )
+            }
+        }
+        return ConverterResult(title: info.filename, sections: sections)
     }
 
     /// Longest-side pixel cap for the decoded image. Mirrors the PDF OCR
@@ -56,8 +84,9 @@ public struct ImageOCRConverter: DocumentConverter {
     /// unbounded bitmap before recognition. Vision has ample detail at this size.
     private static let maxOCRPixelsPerSide = 4000
 
-    /// Decodes `data` to a CGImage that is (a) bounded to `maxOCRPixelsPerSide` on
-    /// its longer side and (b) rotated upright per its EXIF orientation.
+    /// Decodes frame `index` of `source` into a CGImage that is (a) bounded to
+    /// `maxOCRPixelsPerSide` on its longer side and (b) rotated upright per its
+    /// EXIF orientation.
     ///
     /// `CGImageSourceCreateThumbnailAtIndex` (vs. `…CreateImageAtIndex`) lets
     /// ImageIO downsample during decode — so a huge source never fully
@@ -65,17 +94,14 @@ public struct ImageOCRConverter: DocumentConverter {
     /// which camera/phone scans would be OCR'd sideways and return no text.
     /// `…FromImageAlways` decodes from the full image rather than a small embedded
     /// EXIF thumbnail; images already under the cap come back at full resolution.
-    private static func decodeBoundedImage(from data: Data) -> CGImage? {
-        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
-            return nil
-        }
+    private static func boundedImage(from source: CGImageSource, at index: Int) -> CGImage? {
         let options: [CFString: Any] = [
             kCGImageSourceCreateThumbnailFromImageAlways: true,
             kCGImageSourceCreateThumbnailWithTransform: true,
             kCGImageSourceThumbnailMaxPixelSize: maxOCRPixelsPerSide,
             kCGImageSourceShouldCacheImmediately: true,
         ]
-        return CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+        return CGImageSourceCreateThumbnailAtIndex(source, index, options as CFDictionary)
     }
 }
 #endif

--- a/Sources/PicoDocs/Converters/OCR/ImageOCRConverter.swift
+++ b/Sources/PicoDocs/Converters/OCR/ImageOCRConverter.swift
@@ -1,0 +1,51 @@
+//
+//  ImageOCRConverter.swift
+//  PicoDocs
+//
+//  Converts a standalone image (screenshot, scan, photo) by running on-device
+//  Vision OCR over it, making the detector's existing `.image` classification
+//  actually convertible. Registered only where Vision is available (see
+//  `DocumentConverterRegistry.makeDefault`). Honors `StreamInfo.enableOCR`.
+//
+
+#if canImport(Vision)
+import Foundation
+import CoreGraphics
+import ImageIO
+
+public struct ImageOCRConverter: DocumentConverter {
+
+    public init() {}
+
+    public func accepts(_ info: StreamInfo) -> Bool {
+        info.detectedFormat == .image
+    }
+
+    public func convert(_ data: Data, info: StreamInfo) async throws -> ConverterResult {
+        // OCR is the only way to get text out of an image; if the caller disabled
+        // it, decline so the input surfaces as unsupported (its pre-OCR behavior)
+        // rather than as an empty success.
+        guard info.enableOCR else { throw ConverterError.notAccepted }
+
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw PicoDocsError.fileCorrupted
+        }
+
+        try Task.checkCancellation()
+        let text = try VisionOCRService()
+            .recognizeText(in: image)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !text.isEmpty else { throw PicoDocsError.emptyDocument }
+
+        let section = DocumentSection(
+            title: info.filename,
+            kind: .body,
+            markdown: text,
+            metadata: ["extractionMethod": "vision-ocr"]
+        )
+        return ConverterResult(title: info.filename, sections: [section])
+    }
+}
+#endif

--- a/Sources/PicoDocs/Converters/OCR/ImageOCRConverter.swift
+++ b/Sources/PicoDocs/Converters/OCR/ImageOCRConverter.swift
@@ -27,15 +27,18 @@ public struct ImageOCRConverter: DocumentConverter {
         // rather than as an empty success.
         guard info.enableOCR else { throw ConverterError.notAccepted }
 
-        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
-              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
-            throw PicoDocsError.fileCorrupted
-        }
-
         try Task.checkCancellation()
-        let text = try VisionOCRService()
-            .recognizeText(in: image)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Decode + OCR both run off the cooperative pool (see
+        // `runOffCooperativePool`); only `Data` in / `String` out crosses the
+        // boundary, so no non-Sendable `CGImage` escapes.
+        let text = try await VisionOCRService.runOffCooperativePool {
+            guard let image = Self.decodeBoundedImage(from: data) else {
+                throw PicoDocsError.fileCorrupted
+            }
+            return try VisionOCRService()
+                .recognizeText(in: image)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
 
         guard !text.isEmpty else { throw PicoDocsError.emptyDocument }
 
@@ -46,6 +49,33 @@ public struct ImageOCRConverter: DocumentConverter {
             metadata: ["extractionMethod": "vision-ocr"]
         )
         return ConverterResult(title: info.filename, sections: [section])
+    }
+
+    /// Longest-side pixel cap for the decoded image. Mirrors the PDF OCR
+    /// fallback's cap so an oversized scan / panorama / TIFF can't allocate an
+    /// unbounded bitmap before recognition. Vision has ample detail at this size.
+    private static let maxOCRPixelsPerSide = 4000
+
+    /// Decodes `data` to a CGImage that is (a) bounded to `maxOCRPixelsPerSide` on
+    /// its longer side and (b) rotated upright per its EXIF orientation.
+    ///
+    /// `CGImageSourceCreateThumbnailAtIndex` (vs. `…CreateImageAtIndex`) lets
+    /// ImageIO downsample during decode — so a huge source never fully
+    /// materializes — and `…WithTransform` bakes in the orientation tag, without
+    /// which camera/phone scans would be OCR'd sideways and return no text.
+    /// `…FromImageAlways` decodes from the full image rather than a small embedded
+    /// EXIF thumbnail; images already under the cap come back at full resolution.
+    private static func decodeBoundedImage(from data: Data) -> CGImage? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+            return nil
+        }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxOCRPixelsPerSide,
+            kCGImageSourceShouldCacheImmediately: true,
+        ]
+        return CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
     }
 }
 #endif

--- a/Sources/PicoDocs/Converters/OCR/VisionOCRService.swift
+++ b/Sources/PicoDocs/Converters/OCR/VisionOCRService.swift
@@ -49,6 +49,14 @@ struct VisionOCRService: Sendable {
         // (a≈b, b≈c, but a≉c) and so isn't the strict weak ordering `sorted(by:)`
         // requires — violating it is undefined behavior and can trap. Bucketing
         // sorts by the tuple (row, x), which is a proper ordering.
+        //
+        // Note: this yields single-column reading order. Multi-column layouts
+        // (newspaper / academic two-column pages) interleave columns row-by-row.
+        // True column segmentation needs document layout analysis that Vision's
+        // `VNRecognizeTextRequest` doesn't provide at our deployment floor (the
+        // layout-aware `RecognizeDocumentsRequest` is iOS 26+), so it's
+        // intentionally out of scope here rather than handled with a fragile
+        // gap-detection heuristic that could misorder ordinary single-column text.
         let rowHeight = Self.rowHeight
         return observations
             .sorted { lhs, rhs in

--- a/Sources/PicoDocs/Converters/OCR/VisionOCRService.swift
+++ b/Sources/PicoDocs/Converters/OCR/VisionOCRService.swift
@@ -18,9 +18,15 @@ import Vision
 ///
 /// Stateless and `Sendable`. The recognition call is synchronous and
 /// CPU-intensive (Vision offers no async variant on the platforms PicoDocs
-/// targets), so callers invoke it from inside their own `async`
-/// `convert(_:info:)`.
+/// targets — the async `RecognizeTextRequest` is iOS 18 / macOS 15, past our
+/// deployment floor), so callers run it via `runOffCooperativePool` to keep the
+/// blocking work off the Swift concurrency cooperative thread pool.
 struct VisionOCRService: Sendable {
+
+    /// Discretizes Vision's normalized (0...1) y-coordinate into fixed rows so
+    /// observations on the same visual line group together. Also the minimum y
+    /// gap that counts as a new line.
+    private static let rowHeight: CGFloat = 0.012
 
     /// Recognized text as lines in natural reading order (top-to-bottom, then
     /// left-to-right). Empty when the image holds no legible text.
@@ -37,10 +43,19 @@ struct VisionOCRService: Sendable {
         // Vision's bounding boxes are normalized (0...1) with a bottom-left
         // origin. Sort top-to-bottom then left-to-right so multi-column or
         // out-of-order observations assemble into a sensible reading order.
+        //
+        // y is bucketed into discrete rows rather than compared with an epsilon
+        // (`abs(a.y - b.y) > threshold`): an epsilon compare is NOT transitive
+        // (a≈b, b≈c, but a≉c) and so isn't the strict weak ordering `sorted(by:)`
+        // requires — violating it is undefined behavior and can trap. Bucketing
+        // sorts by the tuple (row, x), which is a proper ordering.
+        let rowHeight = Self.rowHeight
         return observations
             .sorted { lhs, rhs in
                 let l = lhs.boundingBox, r = rhs.boundingBox
-                if abs(l.origin.y - r.origin.y) > 0.012 { return l.origin.y > r.origin.y }
+                let rowL = (l.origin.y / rowHeight).rounded(.down)
+                let rowR = (r.origin.y / rowHeight).rounded(.down)
+                if rowL != rowR { return rowL > rowR }   // higher y first (top of page)
                 return l.origin.x < r.origin.x
             }
             .compactMap { $0.topCandidates(1).first?.string }
@@ -52,5 +67,35 @@ struct VisionOCRService: Sendable {
     func recognizeText(in image: CGImage, languages: [String]? = nil) throws -> String {
         try recognizeLines(in: image, languages: languages).joined(separator: "\n")
     }
+
+    /// Runs synchronous, CPU-bound OCR work (image decode / page rasterization +
+    /// Vision recognition) on a background dispatch queue, bridged back via a
+    /// checked continuation.
+    ///
+    /// `VNImageRequestHandler.perform` is synchronous and can run for hundreds of
+    /// ms to seconds. Calling it directly from an `async` converter would occupy
+    /// a cooperative thread-pool thread for that whole duration; the pool is
+    /// width-limited (~core count), so under concurrent/batch conversion that can
+    /// starve unrelated tasks. Offloading keeps the pool responsive. The decode /
+    /// rasterization belongs inside `work` too, so that heavy step is off-pool as
+    /// well and only `Sendable` values cross the boundary.
+    static func runOffCooperativePool<T: Sendable>(
+        _ work: @escaping @Sendable () throws -> T
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(with: Result(catching: work))
+            }
+        }
+    }
+}
+
+/// Hands a non-`Sendable` value to a single background closure. Safe because the
+/// value is transferred, not shared: it is read by exactly one
+/// `runOffCooperativePool` closure and never touched concurrently. Used to pass a
+/// `PDFPage` (PDFKit types aren't `Sendable`) into the off-pool OCR closure.
+struct UnsafeSendableBox<Value>: @unchecked Sendable {
+    let value: Value
+    init(_ value: Value) { self.value = value }
 }
 #endif

--- a/Sources/PicoDocs/Converters/OCR/VisionOCRService.swift
+++ b/Sources/PicoDocs/Converters/OCR/VisionOCRService.swift
@@ -1,0 +1,56 @@
+//
+//  VisionOCRService.swift
+//  PicoDocs
+//
+//  On-device OCR via Apple's Vision framework. System-provided, so there is no
+//  model bundle or third-party dependency — recognition runs entirely on the
+//  device. Shared by `PDFConverter` (fallback for image-only pages) and
+//  `ImageOCRConverter` (standalone images). Apple-platform only: the whole file
+//  is gated on `canImport(Vision)`.
+//
+
+#if canImport(Vision)
+import Foundation
+import CoreGraphics
+import Vision
+
+/// Recognizes text in a `CGImage` using Vision's `VNRecognizeTextRequest`.
+///
+/// Stateless and `Sendable`. The recognition call is synchronous and
+/// CPU-intensive (Vision offers no async variant on the platforms PicoDocs
+/// targets), so callers invoke it from inside their own `async`
+/// `convert(_:info:)`.
+struct VisionOCRService: Sendable {
+
+    /// Recognized text as lines in natural reading order (top-to-bottom, then
+    /// left-to-right). Empty when the image holds no legible text.
+    func recognizeLines(in image: CGImage, languages: [String]? = nil) throws -> [String] {
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+        if let languages { request.recognitionLanguages = languages }
+
+        let handler = VNImageRequestHandler(cgImage: image, options: [:])
+        try handler.perform([request])
+
+        guard let observations = request.results else { return [] }
+        // Vision's bounding boxes are normalized (0...1) with a bottom-left
+        // origin. Sort top-to-bottom then left-to-right so multi-column or
+        // out-of-order observations assemble into a sensible reading order.
+        return observations
+            .sorted { lhs, rhs in
+                let l = lhs.boundingBox, r = rhs.boundingBox
+                if abs(l.origin.y - r.origin.y) > 0.012 { return l.origin.y > r.origin.y }
+                return l.origin.x < r.origin.x
+            }
+            .compactMap { $0.topCandidates(1).first?.string }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// Recognized text as a single newline-joined string (see `recognizeLines`).
+    func recognizeText(in image: CGImage, languages: [String]? = nil) throws -> String {
+        try recognizeLines(in: image, languages: languages).joined(separator: "\n")
+    }
+}
+#endif

--- a/Sources/PicoDocs/Converters/PDFConverter.swift
+++ b/Sources/PicoDocs/Converters/PDFConverter.swift
@@ -70,7 +70,7 @@ public struct PDFConverter: DocumentConverter {
             #if canImport(Vision)
             if info.enableOCR {
                 let boxedPage = UnsafeSendableBox(page)
-                let ocrText = try await VisionOCRService.runOffCooperativePool { () -> String in
+                let ocrText = try await VisionOCRService.runOffCooperativePool { () throws -> String in
                     guard let image = Self.renderImage(of: boxedPage.value, dpi: Self.ocrRenderDPI) else {
                         return ""
                     }
@@ -112,9 +112,12 @@ public struct PDFConverter: DocumentConverter {
     private static let maxOCRPixelsPerSide: CGFloat = 4000
 
     /// Renders `page` to an opaque RGB bitmap at `dpi`, capped to
-    /// `maxOCRPixelsPerSide` on the longer side.
+    /// `maxOCRPixelsPerSide` on the longer side. Uses the crop box (the visible
+    /// page) rather than the media box, so trim/bleed or redacted margins outside
+    /// the visible area aren't OCR'd into the text. `bounds(for:)` falls back to
+    /// the media box when no crop box is set.
     private static func renderImage(of page: PDFPage, dpi: CGFloat) -> CGImage? {
-        let box = page.bounds(for: .mediaBox)
+        let box = page.bounds(for: .cropBox)
         guard box.width > 0, box.height > 0 else { return nil }
 
         let scale = min(dpi / 72.0, maxOCRPixelsPerSide / max(box.width, box.height))
@@ -138,7 +141,7 @@ public struct PDFConverter: DocumentConverter {
         context.fill(CGRect(x: 0, y: 0, width: pixelWidth, height: pixelHeight))
         context.scaleBy(x: scale, y: scale)
         context.translateBy(x: -box.minX, y: -box.minY)
-        page.draw(with: .mediaBox, to: context)
+        page.draw(with: .cropBox, to: context)
         return context.makeImage()
     }
     #endif

--- a/Sources/PicoDocs/Converters/PDFConverter.swift
+++ b/Sources/PicoDocs/Converters/PDFConverter.swift
@@ -3,6 +3,11 @@
 //  PicoDocs
 //
 //  Extracts text from PDFs via PDFKit, one section per page (carrying pageRange).
+//  Pages with no selectable text (scanned / image-only PDFs) fall back to
+//  on-device Vision OCR when `StreamInfo.enableOCR` is set and Vision is
+//  available; each section records which path produced it in
+//  `metadata["extractionMethod"]` ("pdfkit" or "vision-ocr").
+//
 //  PDFKit is unavailable on tvOS/watchOS, so the whole converter is gated on
 //  `canImport(PDFKit)` (the registry skips it where it can't compile).
 //
@@ -10,6 +15,9 @@
 #if canImport(PDFKit)
 import Foundation
 import PDFKit
+#if canImport(Vision)
+import CoreGraphics
+#endif
 
 public struct PDFConverter: DocumentConverter {
 
@@ -32,14 +40,35 @@ public struct PDFConverter: DocumentConverter {
         for index in 0..<document.pageCount {
             try Task.checkCancellation()
             guard let page = document.page(at: index) else { continue }
-            let text = (page.string ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !text.isEmpty else { continue }
             let pageNumber = index + 1
-            sections.append(DocumentSection(
-                kind: .body,
-                markdown: text,
-                pageRange: pageNumber...pageNumber
-            ))
+
+            let text = (page.string ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty {
+                sections.append(DocumentSection(
+                    kind: .body,
+                    markdown: text,
+                    pageRange: pageNumber...pageNumber,
+                    metadata: ["extractionMethod": "pdfkit"]
+                ))
+                continue
+            }
+
+            // No selectable text on this page — likely scanned or exported as an
+            // image. Fall back to on-device OCR when enabled and available.
+            #if canImport(Vision)
+            if info.enableOCR {
+                let ocrText = Self.recognizeText(on: page)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if !ocrText.isEmpty {
+                    sections.append(DocumentSection(
+                        kind: .body,
+                        markdown: ocrText,
+                        pageRange: pageNumber...pageNumber,
+                        metadata: ["extractionMethod": "vision-ocr"]
+                    ))
+                }
+            }
+            #endif
         }
 
         guard !sections.isEmpty else { throw PicoDocsError.emptyDocument }
@@ -55,5 +84,51 @@ public struct PDFConverter: DocumentConverter {
             sections: sections
         )
     }
+
+    #if canImport(Vision)
+    /// Rasterizes a page with no selectable text and OCRs it. Returns "" when the
+    /// page can't be rendered or holds no legible text.
+    private static func recognizeText(on page: PDFPage) -> String {
+        guard let image = renderImage(of: page, dpi: ocrRenderDPI) else { return "" }
+        return (try? VisionOCRService().recognizeText(in: image)) ?? ""
+    }
+
+    /// Render resolution for OCR. 300 DPI is a common scan resolution and gives
+    /// Vision ample detail; `renderImage` additionally caps the pixel dimensions
+    /// so an unusually large page can't allocate an unbounded bitmap.
+    private static let ocrRenderDPI: CGFloat = 300
+    private static let maxOCRPixelsPerSide: CGFloat = 4000
+
+    /// Renders `page` to an opaque RGB bitmap at `dpi`, capped to
+    /// `maxOCRPixelsPerSide` on the longer side.
+    private static func renderImage(of page: PDFPage, dpi: CGFloat) -> CGImage? {
+        let box = page.bounds(for: .mediaBox)
+        guard box.width > 0, box.height > 0 else { return nil }
+
+        let scale = min(dpi / 72.0, maxOCRPixelsPerSide / max(box.width, box.height))
+        let pixelWidth = Int((box.width * scale).rounded())
+        let pixelHeight = Int((box.height * scale).rounded())
+        guard pixelWidth > 0, pixelHeight > 0,
+              let context = CGContext(
+                data: nil,
+                width: pixelWidth,
+                height: pixelHeight,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+              )
+        else { return nil }
+
+        // Scanned pages are often unpainted (transparent) where there's no ink;
+        // fill white so OCR sees dark-on-light text.
+        context.setFillColor(gray: 1, alpha: 1)
+        context.fill(CGRect(x: 0, y: 0, width: pixelWidth, height: pixelHeight))
+        context.scaleBy(x: scale, y: scale)
+        context.translateBy(x: -box.minX, y: -box.minY)
+        page.draw(with: .mediaBox, to: context)
+        return context.makeImage()
+    }
+    #endif
 }
 #endif

--- a/Sources/PicoDocs/Converters/PDFConverter.swift
+++ b/Sources/PicoDocs/Converters/PDFConverter.swift
@@ -55,10 +55,29 @@ public struct PDFConverter: DocumentConverter {
 
             // No selectable text on this page — likely scanned or exported as an
             // image. Fall back to on-device OCR when enabled and available.
+            //
+            // Render + recognize run off the cooperative pool (both are
+            // synchronous and CPU-heavy). `PDFPage` isn't `Sendable`, so it's
+            // transferred into the single off-pool closure via `UnsafeSendableBox`
+            // — safe because nothing else touches it meanwhile.
+            //
+            // A Vision recognition *error* propagates (fails the conversion)
+            // rather than being swallowed: that matches the registry's
+            // fail-loudly contract and avoids reporting a genuine OCR failure as a
+            // misleading `emptyDocument`. A legitimate "no legible text" result is
+            // an empty string, not an error, so it correctly skips the page. A
+            // page that can't be rasterized at all also skips (render → nil → "").
             #if canImport(Vision)
             if info.enableOCR {
-                let ocrText = Self.recognizeText(on: page)
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let boxedPage = UnsafeSendableBox(page)
+                let ocrText = try await VisionOCRService.runOffCooperativePool { () -> String in
+                    guard let image = Self.renderImage(of: boxedPage.value, dpi: Self.ocrRenderDPI) else {
+                        return ""
+                    }
+                    return try VisionOCRService()
+                        .recognizeText(in: image)
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                }
                 if !ocrText.isEmpty {
                     sections.append(DocumentSection(
                         kind: .body,
@@ -86,13 +105,6 @@ public struct PDFConverter: DocumentConverter {
     }
 
     #if canImport(Vision)
-    /// Rasterizes a page with no selectable text and OCRs it. Returns "" when the
-    /// page can't be rendered or holds no legible text.
-    private static func recognizeText(on page: PDFPage) -> String {
-        guard let image = renderImage(of: page, dpi: ocrRenderDPI) else { return "" }
-        return (try? VisionOCRService().recognizeText(in: image)) ?? ""
-    }
-
     /// Render resolution for OCR. 300 DPI is a common scan resolution and gives
     /// Vision ample detail; `renderImage` additionally caps the pixel dimensions
     /// so an unusually large page can't allocate an unbounded bitmap.

--- a/Sources/PicoDocs/Extensions/UTType.swift
+++ b/Sources/PicoDocs/Extensions/UTType.swift
@@ -26,17 +26,29 @@ public extension UTType {
     static let webloc = UTType(importedAs: "com.apple.web-internet-location")
 
     /// Array of all supported documents
-    static let supportedDocumentTypes = [
-        .folder, .directory,
-        .webloc,
-        .doc, .docx, .xlsx,
-        .epub,
-        .pdf, .rtf, .rtfd, .text, .flatRTFD, .plainText, .utf8PlainText, xml,
-        .spreadsheet, .commaSeparatedText,
-        .internetLocation, .internetShortcut, .url, .urlBookmarkData, .html, .xhtml,
-        .sourceCode, .json, .objectiveCSource, .phpScript, .perlScript, .shellScript, .script, .javaScript, .pythonScript, .assemblyLanguageSource,
-        .emailMessage, .spreadsheet,
-    ]
+    static let supportedDocumentTypes: [UTType] = {
+        var types: [UTType] = [
+            .folder, .directory,
+            .webloc,
+            .doc, .docx, .xlsx,
+            .epub,
+            .pdf, .rtf, .rtfd, .text, .flatRTFD, .plainText, .utf8PlainText, .xml,
+            .spreadsheet, .commaSeparatedText,
+            .internetLocation, .internetShortcut, .url, .urlBookmarkData, .html, .xhtml,
+            .sourceCode, .json, .objectiveCSource, .phpScript, .perlScript, .shellScript, .script, .javaScript, .pythonScript, .assemblyLanguageSource,
+            .emailMessage, .spreadsheet,
+        ]
+        #if canImport(Vision)
+        // Standalone images are convertible via on-device OCR (ImageOCRConverter),
+        // which is registered only where Vision exists — so claim image support
+        // under the same gate. `.image` is abstract; `isSupported` matches by
+        // conformance, so concrete PNG/JPEG/HEIC/TIFF/… all qualify. Without this,
+        // the `PicoDocument(url:)` path marks image files unsupported even though
+        // the engine can now OCR them.
+        types.append(.image)
+        #endif
+        return types
+    }()
 
 
     /// Returns true if type is listed in `supportedDocumentTypes`

--- a/Sources/PicoDocs/Models/StreamInfo.swift
+++ b/Sources/PicoDocs/Models/StreamInfo.swift
@@ -64,6 +64,13 @@ public struct StreamInfo: Sendable, Equatable {
     /// Ignored by non-HTML converters.
     public var enhanceReadability: Bool
 
+    /// Whether converters may run on-device OCR (Apple Vision) to recover text
+    /// the source doesn't expose as selectable text: image-only / scanned PDF
+    /// pages, and standalone images. Defaults to `true`; set `false` to skip OCR
+    /// (faster — image inputs then surface as unsupported). No-op where Vision is
+    /// unavailable.
+    public var enableOCR: Bool
+
     public init(
         filename: String? = nil,
         fileExtension: String? = nil,
@@ -73,7 +80,8 @@ public struct StreamInfo: Sendable, Equatable {
         charset: String.Encoding? = nil,
         detectedFormat: DetectedFormat? = nil,
         confidence: Double = 0,
-        enhanceReadability: Bool = true
+        enhanceReadability: Bool = true,
+        enableOCR: Bool = true
     ) {
         self.filename = filename
         self.fileExtension = fileExtension
@@ -84,5 +92,6 @@ public struct StreamInfo: Sendable, Equatable {
         self.detectedFormat = detectedFormat
         self.confidence = confidence
         self.enhanceReadability = enhanceReadability
+        self.enableOCR = enableOCR
     }
 }

--- a/Sources/PicoDocs/PicoDocs.swift
+++ b/Sources/PicoDocs/PicoDocs.swift
@@ -29,6 +29,7 @@ public enum PicoDocsEngine {
         url: URL? = nil,
         charset: String.Encoding? = nil,
         enhanceReadability: Bool = true,
+        enableOCR: Bool = true,
         registry: DocumentConverterRegistry = .default
     ) async throws -> ConverterResult {
         let info = makeStreamInfo(
@@ -36,7 +37,8 @@ public enum PicoDocsEngine {
             mimeType: mimeType,
             url: url,
             charset: charset,
-            enhanceReadability: enhanceReadability
+            enhanceReadability: enhanceReadability,
+            enableOCR: enableOCR
         )
         let resolved = ContentTypeDetector.classify(data, info: info)
         return try await registry.convert(data, info: resolved)
@@ -51,6 +53,7 @@ public enum PicoDocsEngine {
         charset: String.Encoding? = nil,
         to format: ExportFileType = .markdown,
         enhanceReadability: Bool = true,
+        enableOCR: Bool = true,
         registry: DocumentConverterRegistry = .default
     ) async throws -> String {
         let result = try await convert(
@@ -60,6 +63,7 @@ public enum PicoDocsEngine {
             url: url,
             charset: charset,
             enhanceReadability: enhanceReadability,
+            enableOCR: enableOCR,
             registry: registry
         )
         return try DocumentRenderer.render(result, to: format)
@@ -67,7 +71,7 @@ public enum PicoDocsEngine {
 
     // MARK: - StreamInfo construction
 
-    static func makeStreamInfo(filename: String?, mimeType: String?, url: URL?, charset: String.Encoding?, enhanceReadability: Bool = true) -> StreamInfo {
+    static func makeStreamInfo(filename: String?, mimeType: String?, url: URL?, charset: String.Encoding?, enhanceReadability: Bool = true, enableOCR: Bool = true) -> StreamInfo {
         let ext = fileExtension(filename: filename, url: url)
         // Use only the base type (before any ";" parameters) for UTType lookup.
         let baseMIME = mimeType?.split(separator: ";").first.map {
@@ -85,7 +89,8 @@ public enum PicoDocsEngine {
             utType: utType,
             url: url,
             charset: charset ?? encoding(fromMIME: mimeType),
-            enhanceReadability: enhanceReadability
+            enhanceReadability: enhanceReadability,
+            enableOCR: enableOCR
         )
     }
 

--- a/Sources/PicoDocs/PicoDocument+Fetch.swift
+++ b/Sources/PicoDocs/PicoDocument+Fetch.swift
@@ -52,13 +52,15 @@ extension PicoDocument {
     ///   - enhanceReadability: For HTML, run the Readability extraction pass
     ///     (reader-mode: keep the main article, drop nav/ads/boilerplate). Ignored
     ///     by non-HTML formats. Defaults to `true`.
-    public nonisolated func parse(to type: ExportFileType? = nil, recursive: Bool = true, enhanceReadability: Bool = true) async throws {
+    ///   - enableOCR: Allow on-device OCR (Apple Vision) for image-only / scanned
+    ///     PDF pages and standalone images. Defaults to `true`.
+    public nonisolated func parse(to type: ExportFileType? = nil, recursive: Bool = true, enhanceReadability: Bool = true, enableOCR: Bool = true) async throws {
         // Parse children first. A child failure is recorded on the child and is
         // not fatal to the parent.
         if let children = await self.children, recursive {
             for child in children {
                 do {
-                    try await child.parse(to: type, recursive: recursive, enhanceReadability: enhanceReadability)
+                    try await child.parse(to: type, recursive: recursive, enhanceReadability: enhanceReadability, enableOCR: enableOCR)
                 } catch {
                     await child.setError(error)
                 }
@@ -79,7 +81,8 @@ extension PicoDocument {
                 data: originalContent,
                 filename: self.filename,
                 url: self.originURL,
-                enhanceReadability: enhanceReadability
+                enhanceReadability: enhanceReadability,
+                enableOCR: enableOCR
             )
             let exported = try Self.exportedContent(from: result, format: type)
             await updateParsedDocument(result, content: exported)

--- a/Sources/PicoDocs/PicoDocument+Fetch.swift
+++ b/Sources/PicoDocs/PicoDocument+Fetch.swift
@@ -77,9 +77,17 @@ extension PicoDocument {
                 }
                 throw PicoDocsError.emptyDocument
             }
+            // Forward the document's resolved type as a hint. `fetch()` may have
+            // learned it solely from the HTTP `Content-Type` (e.g. an image URL
+            // with no path extension); rebuilding StreamInfo from filename/URL
+            // alone would drop that, so such inputs could miss `.image`
+            // classification and never reach the OCR converter. Passed as a MIME
+            // hint — magic-byte detection still wins for formats that have it.
+            let mimeHint = await self.utType.preferredMIMEType
             let result = try await PicoDocsEngine.convert(
                 data: originalContent,
                 filename: self.filename,
+                mimeType: mimeHint,
                 url: self.originURL,
                 enhanceReadability: enhanceReadability,
                 enableOCR: enableOCR

--- a/Sources/PicoDocs/PicoDocument+Fetch.swift
+++ b/Sources/PicoDocs/PicoDocument+Fetch.swift
@@ -77,13 +77,17 @@ extension PicoDocument {
                 }
                 throw PicoDocsError.emptyDocument
             }
-            // Forward the document's resolved type as a hint. `fetch()` may have
-            // learned it solely from the HTTP `Content-Type` (e.g. an image URL
-            // with no path extension); rebuilding StreamInfo from filename/URL
-            // alone would drop that, so such inputs could miss `.image`
-            // classification and never reach the OCR converter. Passed as a MIME
-            // hint — magic-byte detection still wins for formats that have it.
-            let mimeHint = await self.utType.preferredMIMEType
+            // Forward the document's resolved type as a MIME hint so a type
+            // learned only from a fetched `Content-Type` (e.g. an extension-less
+            // image URL) still reaches the right converter. Skip generic
+            // catch-alls, though: a `.data` (e.g. from an
+            // `application/octet-stream` response) would, via makeStreamInfo's
+            // MIME-over-extension precedence, mask an informative filename
+            // extension like `photo.png` and suppress classification. Magic-byte
+            // detection still wins for formats that have it.
+            let utType = await self.utType
+            let genericTypes: Set<UTType> = [.data, .content, .item, .folder, .directory]
+            let mimeHint = genericTypes.contains(utType) ? nil : utType.preferredMIMEType
             let result = try await PicoDocsEngine.convert(
                 data: originalContent,
                 filename: self.filename,

--- a/Tests/PicoDocsTests/OCRTests.swift
+++ b/Tests/PicoDocsTests/OCRTests.swift
@@ -1,0 +1,115 @@
+//
+//  OCRTests.swift
+//  PicoDocsTests
+//
+//  On-device Vision OCR: the standalone image converter and the PDF fallback for
+//  image-only pages. Fixtures are generated in-process (text rendered to a
+//  bitmap, and an image-only PDF) so the expected text is known and no binaries
+//  are committed. Gated on `canImport(Vision)` — these only build/run on Apple
+//  platforms where Vision is available (the CI target, macOS).
+//
+
+#if canImport(Vision)
+import Foundation
+import Testing
+import CoreGraphics
+import CoreText
+import ImageIO
+import UniformTypeIdentifiers
+@testable import PicoDocs
+
+@Suite("OCR (Vision)")
+struct OCRTests {
+
+    @Test("Image OCR converter extracts text from an image")
+    func imageOCR() async throws {
+        let png = Self.pngData(Self.makeTextImage("Hello Vision World"))
+        let result = try await PicoDocsEngine.convert(data: png, filename: "scan.png")
+        let md = result.markdown()
+        #expect(md.localizedCaseInsensitiveContains("Hello"))
+        #expect(md.localizedCaseInsensitiveContains("World"))
+        #expect(result.sections.first?.metadata["extractionMethod"] == "vision-ocr")
+    }
+
+    @Test("Image input with OCR disabled surfaces as unsupported")
+    func imageOCRDisabled() async throws {
+        let png = Self.pngData(Self.makeTextImage("Hello Vision World"))
+        await #expect(throws: PicoDocsError.self) {
+            _ = try await PicoDocsEngine.convert(data: png, filename: "scan.png", enableOCR: false)
+        }
+    }
+
+    #if canImport(PDFKit)
+    @Test("PDF OCR fallback recovers text from an image-only page")
+    func pdfOCRFallback() async throws {
+        let pdf = Self.imageOnlyPDF(Self.makeTextImage("Scanned Invoice Page"))
+        let result = try await PicoDocsEngine.convert(data: pdf, filename: "scan.pdf")
+        let md = result.markdown()
+        #expect(md.localizedCaseInsensitiveContains("Invoice"))
+        #expect(md.localizedCaseInsensitiveContains("Page"))
+        #expect(result.sections.contains { $0.metadata["extractionMethod"] == "vision-ocr" })
+    }
+
+    @Test("Image-only PDF with OCR disabled yields no text")
+    func pdfOCRDisabled() async throws {
+        let pdf = Self.imageOnlyPDF(Self.makeTextImage("Scanned Invoice Page"))
+        await #expect(throws: PicoDocsError.self) {
+            _ = try await PicoDocsEngine.convert(data: pdf, filename: "scan.pdf", enableOCR: false)
+        }
+    }
+    #endif
+
+    // MARK: - Fixture generation
+
+    /// Renders `text` as crisp black-on-white into a CGImage (origin bottom-left).
+    private static func makeTextImage(_ text: String, width: Int = 1000, height: Int = 260, fontSize: CGFloat = 72) -> CGImage {
+        let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+        )!
+        context.setFillColor(gray: 1, alpha: 1)
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        let font = CTFontCreateWithName("Helvetica-Bold" as CFString, fontSize, nil)
+        let attributes: [CFString: Any] = [
+            kCTFontAttributeName: font,
+            kCTForegroundColorAttributeName: CGColor(gray: 0, alpha: 1),
+        ]
+        let attributed = CFAttributedStringCreate(nil, text as CFString, attributes as CFDictionary)!
+        let line = CTLineCreateWithAttributedString(attributed)
+        context.textPosition = CGPoint(x: 30, y: CGFloat(height) / 2 - fontSize / 3)
+        CTLineDraw(line, context)
+        return context.makeImage()!
+    }
+
+    /// PNG-encodes a CGImage.
+    private static func pngData(_ image: CGImage) -> Data {
+        let data = NSMutableData()
+        let destination = CGImageDestinationCreateWithData(
+            data as CFMutableData, UTType.png.identifier as CFString, 1, nil
+        )!
+        CGImageDestinationAddImage(destination, image, nil)
+        _ = CGImageDestinationFinalize(destination)
+        return data as Data
+    }
+
+    /// Builds a single-page PDF whose only content is `image` — no text layer, so
+    /// PDFKit extraction comes up empty and the OCR fallback runs.
+    private static func imageOnlyPDF(_ image: CGImage) -> Data {
+        let data = NSMutableData()
+        let consumer = CGDataConsumer(data: data as CFMutableData)!
+        var mediaBox = CGRect(x: 0, y: 0, width: image.width, height: image.height)
+        let context = CGContext(consumer: consumer, mediaBox: &mediaBox, nil)!
+        context.beginPDFPage(nil)
+        context.draw(image, in: mediaBox)
+        context.endPDFPage()
+        context.closePDF()
+        return data as Data
+    }
+}
+#endif


### PR DESCRIPTION
## What & why

Two real ingestion gaps today:

- **Scanned / image-only PDFs hard-fail.** `PDFConverter` skips pages with no selectable text, so a fully scanned PDF produces zero sections and then throws `emptyDocument`.
- **Images are detected but unconvertible.** The detector classifies `.image`, but no converter accepts it, so a standalone screenshot/scan throws `documentTypeNotSupported`.

This PR closes both with on-device OCR via **Apple Vision** — system-provided, so there's **no model bundle, no third-party dependency, no MLX/CoreML/Tesseract**.

## Changes

- **`VisionOCRService`** — wraps `VNRecognizeTextRequest` (`.accurate`, language correction), returns lines in reading order. Shared by both consumers below.
- **`PDFConverter`** — pages with no selectable text fall back to OCR: the page is rasterized (300 DPI, pixel-capped to bound memory) and recognized. Every section now records `metadata["extractionMethod"]` = `"pdfkit"` or `"vision-ocr"`.
- **`ImageOCRConverter`** — converts standalone images (`.image`), making the detector's existing classification usable.
- **`enableOCR` flag** (default `true`) threaded through `PicoDocsEngine.convert` / `export` and `PicoDocument.parse`, mirroring the existing `enhanceReadability` pattern. Setting it `false` restores prior behavior (image inputs surface as unsupported; scanned PDF pages yield no text).

## Platform gating

PicoDocs is Apple-only. All Vision code is behind `#if canImport(Vision)`, and the PDF fallback additionally requires `canImport(PDFKit)` — the same pattern the PDF converter already uses for tvOS. Where Vision is unavailable, `enableOCR` is a no-op.

## Testing

`OCRTests` (gated on `canImport(Vision)`) generate fixtures **in-process** — text rendered to a bitmap, and an image-only PDF built with a CGContext PDF — so the expected text is known and **no binaries are committed**. Covers: image OCR, PDF OCR fallback, and the `enableOCR: false` paths. CI builds/tests on macOS, where Vision is available.

> Note: I can't compile Swift in my environment (Linux; Apple-only package), so this leans on CI + review. Flag anything that looks off.

## Context

First of a five-PR roadmap distilled from a SwiftText comparison (OCR → Unicode sanitization → Pages → Keynote → Numbers). This is the OCR slice.

https://claude.ai/code/session_01UGoEuzENbpeVPq4tJdDZBH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGoEuzENbpeVPq4tJdDZBH)_