### PR TITLE
Add Unicode sanitization pass for extracted text

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ PicoDocs supports and processes a variety of document formats:
 - **Export Options**: Convert documents to HTML, Markdown, and JSON formats for LLM compatibility, with embedded and referenced images.
 - **Content Cleanup**: Utilizes Readability to clean HTML content, enhancing focus on the main content similar to Safari's Reader View.
 - **OCR**: On-device text recognition (Apple Vision) for standalone images and scanned / image-only PDF pages — no model bundle or cloud service. Enabled by default; toggle with `enableOCR`.
+- **Unicode Sanitization**: Cleans extracted text for LLM/RAG use — canonical (NFC) normalization, removal of invisible/control characters (zero-width, bidi, soft hyphen, BOM), and folding of Unicode whitespace/line separators to ASCII, while preserving visible typography. Enabled by default; toggle with `sanitizeUnicode`.
 - **Multiple Sources**: Reads local files and iCloud files.
 
 ## How It Works

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PicoDocs supports and processes a variety of document formats:
 - **Export Options**: Convert documents to HTML, Markdown, and JSON formats for LLM compatibility, with embedded and referenced images.
 - **Content Cleanup**: Utilizes Readability to clean HTML content, enhancing focus on the main content similar to Safari's Reader View.
 - **OCR**: On-device text recognition (Apple Vision) for standalone images and scanned / image-only PDF pages — no model bundle or cloud service. Enabled by default; toggle with `enableOCR`.
-- **Unicode Sanitization**: Cleans extracted text for LLM/RAG use — canonical (NFC) normalization, removal of invisible/control characters (zero-width, bidi, soft hyphen, BOM), and folding of Unicode whitespace/line separators to ASCII, while preserving visible typography. Enabled by default; toggle with `sanitizeUnicode`.
+- **Unicode Sanitization** *(opt-in)*: On request (`sanitizeUnicode: true`), cleans extracted text for LLM/RAG use — canonical (NFC) normalization, removal of invisible/control characters (zero-width, bidi, soft hyphen, BOM), and folding of Unicode whitespace/line separators to ASCII — while preserving visible typography (and ZWJ/ZWNJ joiners). Off by default while it post-processes generated Markdown; per-converter integration is planned.
 - **Multiple Sources**: Reads local files and iCloud files.
 
 ## How It Works

--- a/Sources/PicoDocs/Models/StreamInfo.swift
+++ b/Sources/PicoDocs/Models/StreamInfo.swift
@@ -73,8 +73,14 @@ public struct StreamInfo: Sendable, Equatable {
 
     /// Whether extracted text is run through `UnicodeSanitizer` (NFC + removal of
     /// invisible/control characters, folding Unicode whitespace/line separators to
-    /// ASCII). Defaults to `true`; applied by `PicoDocsEngine.convert` to the
-    /// result's text. Preserves visible typography (smart quotes, dashes, accents).
+    /// ASCII; preserves visible typography). Applied by `PicoDocsEngine.convert`
+    /// to the result's text.
+    ///
+    /// Defaults to `false` (opt-in): the pass currently runs on already-built
+    /// Markdown, so for inputs with special characters in structurally-significant
+    /// positions (a line-leading marker, a link/image destination, a CSV cell
+    /// edge) it can alter Markdown structure. Per-converter (pre-Markdown)
+    /// integration that makes it safe to enable by default is a planned follow-up.
     public var sanitizeUnicode: Bool
 
     public init(
@@ -88,7 +94,7 @@ public struct StreamInfo: Sendable, Equatable {
         confidence: Double = 0,
         enhanceReadability: Bool = true,
         enableOCR: Bool = true,
-        sanitizeUnicode: Bool = true
+        sanitizeUnicode: Bool = false
     ) {
         self.filename = filename
         self.fileExtension = fileExtension

--- a/Sources/PicoDocs/Models/StreamInfo.swift
+++ b/Sources/PicoDocs/Models/StreamInfo.swift
@@ -71,6 +71,12 @@ public struct StreamInfo: Sendable, Equatable {
     /// unavailable.
     public var enableOCR: Bool
 
+    /// Whether extracted text is run through `UnicodeSanitizer` (NFC + removal of
+    /// invisible/control characters, folding Unicode whitespace/line separators to
+    /// ASCII). Defaults to `true`; applied by `PicoDocsEngine.convert` to the
+    /// result's text. Preserves visible typography (smart quotes, dashes, accents).
+    public var sanitizeUnicode: Bool
+
     public init(
         filename: String? = nil,
         fileExtension: String? = nil,
@@ -81,7 +87,8 @@ public struct StreamInfo: Sendable, Equatable {
         detectedFormat: DetectedFormat? = nil,
         confidence: Double = 0,
         enhanceReadability: Bool = true,
-        enableOCR: Bool = true
+        enableOCR: Bool = true,
+        sanitizeUnicode: Bool = true
     ) {
         self.filename = filename
         self.fileExtension = fileExtension
@@ -93,5 +100,6 @@ public struct StreamInfo: Sendable, Equatable {
         self.confidence = confidence
         self.enhanceReadability = enhanceReadability
         self.enableOCR = enableOCR
+        self.sanitizeUnicode = sanitizeUnicode
     }
 }

--- a/Sources/PicoDocs/PicoDocs.swift
+++ b/Sources/PicoDocs/PicoDocs.swift
@@ -46,7 +46,17 @@ public enum PicoDocsEngine {
         let result = try await registry.convert(data, info: resolved)
         // Central post-process: clean the extracted text once, so every converter
         // and every caller (convert / export / PicoDocument.parse) benefits.
-        return resolved.sanitizeUnicode ? UnicodeSanitizer.sanitize(result) : result
+        guard resolved.sanitizeUnicode else { return result }
+        let sanitized = UnicodeSanitizer.sanitize(result)
+        // Converters reject empty input before this pass, but sanitizing can empty
+        // a result that held only removable characters — re-check so we don't
+        // surface a blank, "successful" document. (Image-bearing results are never
+        // considered empty: their byte carriers live in `.image` sections.)
+        if sanitized.markdown().trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           !sanitized.sections.contains(where: { $0.kind == .image }) {
+            throw PicoDocsError.emptyDocument
+        }
+        return sanitized
     }
 
     /// Convert and render to a specific `ExportFileType` (defaults to Markdown).

--- a/Sources/PicoDocs/PicoDocs.swift
+++ b/Sources/PicoDocs/PicoDocs.swift
@@ -30,6 +30,7 @@ public enum PicoDocsEngine {
         charset: String.Encoding? = nil,
         enhanceReadability: Bool = true,
         enableOCR: Bool = true,
+        sanitizeUnicode: Bool = true,
         registry: DocumentConverterRegistry = .default
     ) async throws -> ConverterResult {
         let info = makeStreamInfo(
@@ -38,10 +39,14 @@ public enum PicoDocsEngine {
             url: url,
             charset: charset,
             enhanceReadability: enhanceReadability,
-            enableOCR: enableOCR
+            enableOCR: enableOCR,
+            sanitizeUnicode: sanitizeUnicode
         )
         let resolved = ContentTypeDetector.classify(data, info: info)
-        return try await registry.convert(data, info: resolved)
+        let result = try await registry.convert(data, info: resolved)
+        // Central post-process: clean the extracted text once, so every converter
+        // and every caller (convert / export / PicoDocument.parse) benefits.
+        return resolved.sanitizeUnicode ? UnicodeSanitizer.sanitize(result) : result
     }
 
     /// Convert and render to a specific `ExportFileType` (defaults to Markdown).
@@ -54,6 +59,7 @@ public enum PicoDocsEngine {
         to format: ExportFileType = .markdown,
         enhanceReadability: Bool = true,
         enableOCR: Bool = true,
+        sanitizeUnicode: Bool = true,
         registry: DocumentConverterRegistry = .default
     ) async throws -> String {
         let result = try await convert(
@@ -64,6 +70,7 @@ public enum PicoDocsEngine {
             charset: charset,
             enhanceReadability: enhanceReadability,
             enableOCR: enableOCR,
+            sanitizeUnicode: sanitizeUnicode,
             registry: registry
         )
         return try DocumentRenderer.render(result, to: format)
@@ -71,7 +78,7 @@ public enum PicoDocsEngine {
 
     // MARK: - StreamInfo construction
 
-    static func makeStreamInfo(filename: String?, mimeType: String?, url: URL?, charset: String.Encoding?, enhanceReadability: Bool = true, enableOCR: Bool = true) -> StreamInfo {
+    static func makeStreamInfo(filename: String?, mimeType: String?, url: URL?, charset: String.Encoding?, enhanceReadability: Bool = true, enableOCR: Bool = true, sanitizeUnicode: Bool = true) -> StreamInfo {
         let ext = fileExtension(filename: filename, url: url)
         // Use only the base type (before any ";" parameters) for UTType lookup.
         let baseMIME = mimeType?.split(separator: ";").first.map {
@@ -90,7 +97,8 @@ public enum PicoDocsEngine {
             url: url,
             charset: charset ?? encoding(fromMIME: mimeType),
             enhanceReadability: enhanceReadability,
-            enableOCR: enableOCR
+            enableOCR: enableOCR,
+            sanitizeUnicode: sanitizeUnicode
         )
     }
 

--- a/Sources/PicoDocs/PicoDocs.swift
+++ b/Sources/PicoDocs/PicoDocs.swift
@@ -30,7 +30,7 @@ public enum PicoDocsEngine {
         charset: String.Encoding? = nil,
         enhanceReadability: Bool = true,
         enableOCR: Bool = true,
-        sanitizeUnicode: Bool = true,
+        sanitizeUnicode: Bool = false,
         registry: DocumentConverterRegistry = .default
     ) async throws -> ConverterResult {
         let info = makeStreamInfo(
@@ -44,8 +44,12 @@ public enum PicoDocsEngine {
         )
         let resolved = ContentTypeDetector.classify(data, info: info)
         let result = try await registry.convert(data, info: resolved)
-        // Central post-process: clean the extracted text once, so every converter
-        // and every caller (convert / export / PicoDocument.parse) benefits.
+        // Opt-in post-process (default off): clean the extracted text once so every
+        // caller (convert / export / PicoDocument.parse) benefits. NOTE: this runs
+        // on already-built Markdown, so it can alter Markdown structure for inputs
+        // with special characters in structural spots (line-leading markers,
+        // link/image destinations, CSV cell edges) — hence opt-in until a
+        // per-converter (pre-Markdown) pass lands. See `UnicodeSanitizer`.
         guard resolved.sanitizeUnicode else { return result }
         let sanitized = UnicodeSanitizer.sanitize(result)
         // Converters reject empty input before this pass, but sanitizing can empty
@@ -69,7 +73,7 @@ public enum PicoDocsEngine {
         to format: ExportFileType = .markdown,
         enhanceReadability: Bool = true,
         enableOCR: Bool = true,
-        sanitizeUnicode: Bool = true,
+        sanitizeUnicode: Bool = false,
         registry: DocumentConverterRegistry = .default
     ) async throws -> String {
         let result = try await convert(
@@ -88,7 +92,7 @@ public enum PicoDocsEngine {
 
     // MARK: - StreamInfo construction
 
-    static func makeStreamInfo(filename: String?, mimeType: String?, url: URL?, charset: String.Encoding?, enhanceReadability: Bool = true, enableOCR: Bool = true, sanitizeUnicode: Bool = true) -> StreamInfo {
+    static func makeStreamInfo(filename: String?, mimeType: String?, url: URL?, charset: String.Encoding?, enhanceReadability: Bool = true, enableOCR: Bool = true, sanitizeUnicode: Bool = false) -> StreamInfo {
         let ext = fileExtension(filename: filename, url: url)
         // Use only the base type (before any ";" parameters) for UTType lookup.
         let baseMIME = mimeType?.split(separator: ";").first.map {

--- a/Sources/PicoDocs/PicoDocument+Fetch.swift
+++ b/Sources/PicoDocs/PicoDocument+Fetch.swift
@@ -56,8 +56,8 @@ extension PicoDocument {
     ///     PDF pages and standalone images. Defaults to `true`.
     ///   - sanitizeUnicode: Run extracted text through `UnicodeSanitizer`
     ///     (NFC + invisible/control-character removal, whitespace folding).
-    ///     Defaults to `true`.
-    public nonisolated func parse(to type: ExportFileType? = nil, recursive: Bool = true, enhanceReadability: Bool = true, enableOCR: Bool = true, sanitizeUnicode: Bool = true) async throws {
+    ///     Defaults to `false` (opt-in) — see `StreamInfo.sanitizeUnicode`.
+    public nonisolated func parse(to type: ExportFileType? = nil, recursive: Bool = true, enhanceReadability: Bool = true, enableOCR: Bool = true, sanitizeUnicode: Bool = false) async throws {
         // Parse children first. A child failure is recorded on the child and is
         // not fatal to the parent.
         if let children = await self.children, recursive {

--- a/Sources/PicoDocs/PicoDocument+Fetch.swift
+++ b/Sources/PicoDocs/PicoDocument+Fetch.swift
@@ -54,13 +54,16 @@ extension PicoDocument {
     ///     by non-HTML formats. Defaults to `true`.
     ///   - enableOCR: Allow on-device OCR (Apple Vision) for image-only / scanned
     ///     PDF pages and standalone images. Defaults to `true`.
-    public nonisolated func parse(to type: ExportFileType? = nil, recursive: Bool = true, enhanceReadability: Bool = true, enableOCR: Bool = true) async throws {
+    ///   - sanitizeUnicode: Run extracted text through `UnicodeSanitizer`
+    ///     (NFC + invisible/control-character removal, whitespace folding).
+    ///     Defaults to `true`.
+    public nonisolated func parse(to type: ExportFileType? = nil, recursive: Bool = true, enhanceReadability: Bool = true, enableOCR: Bool = true, sanitizeUnicode: Bool = true) async throws {
         // Parse children first. A child failure is recorded on the child and is
         // not fatal to the parent.
         if let children = await self.children, recursive {
             for child in children {
                 do {
-                    try await child.parse(to: type, recursive: recursive, enhanceReadability: enhanceReadability, enableOCR: enableOCR)
+                    try await child.parse(to: type, recursive: recursive, enhanceReadability: enhanceReadability, enableOCR: enableOCR, sanitizeUnicode: sanitizeUnicode)
                 } catch {
                     await child.setError(error)
                 }
@@ -94,7 +97,8 @@ extension PicoDocument {
                 mimeType: mimeHint,
                 url: self.originURL,
                 enhanceReadability: enhanceReadability,
-                enableOCR: enableOCR
+                enableOCR: enableOCR,
+                sanitizeUnicode: sanitizeUnicode
             )
             let exported = try Self.exportedContent(from: result, format: type)
             await updateParsedDocument(result, content: exported)

--- a/Sources/PicoDocs/Sanitization/UnicodeSanitizer.swift
+++ b/Sources/PicoDocs/Sanitization/UnicodeSanitizer.swift
@@ -1,0 +1,95 @@
+//
+//  UnicodeSanitizer.swift
+//  PicoDocs
+//
+//  Conservative Unicode clean-up for extracted text, so downstream LLM / RAG
+//  consumers get well-formed text without invisible, control, or layout-only
+//  characters that hurt tokenization and matching. Applied centrally by
+//  `PicoDocsEngine.convert` to every text section, guarded by
+//  `StreamInfo.sanitizeUnicode`.
+//
+//  Deliberately non-lossy for *visible* content: it does NOT touch smart quotes,
+//  dashes, ellipses, accents, or other legitimate typography. It only:
+//    - removes invisible / control characters (zero-width, bidi, soft hyphen,
+//      BOM, C0/C1 controls, the U+FFFD replacement char),
+//    - folds Unicode space variants to a plain space and line/paragraph
+//      separators (and CR/CRLF/NEL) to a newline,
+//    - applies canonical composition (NFC, *not* the lossy NFKC, so ligatures
+//      and full-width forms are preserved).
+//
+//  `sanitize(_:)` is idempotent.
+//
+
+import Foundation
+
+public enum UnicodeSanitizer {
+
+    /// Cleans a single string. See the type documentation for the exact set of
+    /// transforms. Tab and newline are preserved; CR / CRLF / NEL collapse to a
+    /// single newline.
+    public static func sanitize(_ string: String) -> String {
+        guard !string.isEmpty else { return string }
+
+        // Normalize line endings up front so CR / CRLF fold to LF without
+        // producing extra blank lines in the scalar pass below.
+        var source = string
+        if source.contains("\r") {
+            source = source
+                .replacingOccurrences(of: "\r\n", with: "\n")
+                .replacingOccurrences(of: "\r", with: "\n")
+        }
+
+        var output = ""
+        output.unicodeScalars.reserveCapacity(source.unicodeScalars.count)
+        for scalar in source.unicodeScalars {
+            switch scalar.value {
+            // Keep tab and newline.
+            case 0x09, 0x0A:
+                output.unicodeScalars.append(scalar)
+            // NEL (next line) → newline.
+            case 0x85:
+                output.unicodeScalars.append("\n")
+            // Other C0 controls, DEL, and C1 controls → drop.
+            case 0x00...0x1F, 0x7F...0x9F:
+                break
+            // Zero-width / invisible formatting, soft hyphen, word joiner, BOM.
+            case 0x00AD, 0x200B, 0x200C, 0x200D, 0x2060, 0xFEFF:
+                break
+            // Bidirectional formatting controls.
+            case 0x200E, 0x200F, 0x202A...0x202E, 0x2066...0x2069:
+                break
+            // Unicode space variants → ASCII space.
+            case 0x00A0, 0x1680, 0x2000...0x200A, 0x202F, 0x205F, 0x3000:
+                output.unicodeScalars.append(" ")
+            // Line / paragraph separators → newline.
+            case 0x2028, 0x2029:
+                output.unicodeScalars.append("\n")
+            // Replacement character (a failed decode) → drop.
+            case 0xFFFD:
+                break
+            default:
+                output.unicodeScalars.append(scalar)
+            }
+        }
+
+        // Canonical composition (NFC): combine base + combining marks, etc.
+        return output.precomposedStringWithCanonicalMapping
+    }
+
+    /// Cleans the text-bearing fields of a `ConverterResult` — section `markdown`
+    /// and titles, plus the document title/author. Binary / provenance fields are
+    /// left untouched: section `metadata` (may carry base64 image bytes),
+    /// `sourcePath`, `sheetName`, and `cover`.
+    static func sanitize(_ result: ConverterResult) -> ConverterResult {
+        var sanitized = result
+        sanitized.title = result.title.map { sanitize($0) }
+        sanitized.author = result.author.map { sanitize($0) }
+        sanitized.sections = result.sections.map { section in
+            var copy = section
+            copy.markdown = sanitize(section.markdown)
+            copy.title = section.title.map { sanitize($0) }
+            return copy
+        }
+        return sanitized
+    }
+}

--- a/Sources/PicoDocs/Sanitization/UnicodeSanitizer.swift
+++ b/Sources/PicoDocs/Sanitization/UnicodeSanitizer.swift
@@ -9,11 +9,15 @@
 //  `StreamInfo.sanitizeUnicode`.
 //
 //  Deliberately non-lossy for *visible* content: it does NOT touch smart quotes,
-//  dashes, ellipses, accents, or other legitimate typography. It only:
-//    - removes invisible / control characters (zero-width, bidi, soft hyphen,
-//      BOM, C0/C1 controls, the U+FFFD replacement char),
-//    - folds Unicode space variants to a plain space and line/paragraph
-//      separators (and CR/CRLF/NEL) to a newline,
+//  dashes, ellipses, accents, ZWJ/ZWNJ joiners (which shape scripts and compose
+//  emoji), or other legitimate typography. It only:
+//    - removes invisible / control characters (zero-width space, word joiner,
+//      soft hyphen, BOM, bidi controls, other C0/C1 controls, the U+FFFD
+//      replacement char),
+//    - normalizes line endings (CR / CRLF / LF) to a single newline, and folds
+//      the other vertical separators (NEL, form feed, line/paragraph separators)
+//      and Unicode space variants to a plain space — never injecting a newline
+//      into already-built Markdown,
 //    - applies canonical composition (NFC, *not* the lossy NFKC, so ligatures
 //      and full-width forms are preserved).
 //
@@ -52,24 +56,26 @@ public enum UnicodeSanitizer {
             // Keep tab and (standalone) newline.
             case 0x09, 0x0A:
                 scalars.append(scalar)
-            // NEL (next line) → newline.
-            case 0x85:
-                scalars.append("\n")
+            // Vertical separators converters DON'T already flatten — NEL, form
+            // feed (page break), and line/paragraph separators — fold to a space.
+            // Not a newline: this pass runs after Markdown is built, so a stray
+            // newline would split table rows etc.; a space keeps the word boundary.
+            case 0x0C, 0x85, 0x2028, 0x2029:
+                scalars.append(" ")
             // Other C0 controls, DEL, and C1 controls → drop.
             case 0x00...0x1F, 0x7F...0x9F:
                 break
-            // Zero-width / invisible formatting, soft hyphen, word joiner, BOM.
-            case 0x00AD, 0x200B, 0x200C, 0x200D, 0x2060, 0xFEFF:
+            // Zero-width space, word joiner, soft hyphen, BOM → drop. ZWNJ (U+200C)
+            // and ZWJ (U+200D) are intentionally kept: they shape Persian/Indic
+            // text and compose emoji (e.g. 👨‍👩‍👧‍👦), i.e. they're visible content.
+            case 0x00AD, 0x200B, 0x2060, 0xFEFF:
                 break
-            // Bidirectional formatting controls.
-            case 0x200E, 0x200F, 0x202A...0x202E, 0x2066...0x2069:
+            // Bidirectional formatting controls (incl. U+061C Arabic Letter Mark).
+            case 0x061C, 0x200E, 0x200F, 0x202A...0x202E, 0x2066...0x2069:
                 break
             // Unicode space variants → ASCII space.
             case 0x00A0, 0x1680, 0x2000...0x200A, 0x202F, 0x205F, 0x3000:
                 scalars.append(" ")
-            // Line / paragraph separators → newline.
-            case 0x2028, 0x2029:
-                scalars.append("\n")
             // Replacement character (a failed decode) → drop.
             case 0xFFFD:
                 break
@@ -82,10 +88,10 @@ public enum UnicodeSanitizer {
         return String(String.UnicodeScalarView(scalars)).precomposedStringWithCanonicalMapping
     }
 
-    /// Cleans the text-bearing fields of a `ConverterResult` — section `markdown`
-    /// and titles, plus the document title/author. Binary / provenance fields are
-    /// left untouched: section `metadata` (may carry base64 image bytes),
-    /// `sourcePath`, `sheetName`, and `cover`.
+    /// Cleans the text-bearing fields of a `ConverterResult` — section `markdown`,
+    /// titles, and (for non-image sections) `metadata` values — plus the document
+    /// title/author. Image byte-carrier sections' `metadata` is left untouched (it
+    /// holds base64 image data); `sourcePath`, `sheetName`, and `cover` are too.
     static func sanitize(_ result: ConverterResult) -> ConverterResult {
         var sanitized = result
         sanitized.title = result.title.map { sanitize($0) }
@@ -94,6 +100,13 @@ public enum UnicodeSanitizer {
             var copy = section
             copy.markdown = sanitize(section.markdown)
             copy.title = section.title.map { sanitize($0) }
+            // Sanitize text-bearing metadata too — e.g. CSVConverter keeps the
+            // lossless body in metadata["csv"], which the CSV renderer prefers over
+            // the Markdown table. Skip image byte-carrier sections, whose metadata
+            // holds base64 image data that must not be altered.
+            if section.kind != .image {
+                copy.metadata = section.metadata.mapValues { sanitize($0) }
+            }
             return copy
         }
         return sanitized

--- a/Sources/PicoDocs/Sanitization/UnicodeSanitizer.swift
+++ b/Sources/PicoDocs/Sanitization/UnicodeSanitizer.swift
@@ -23,6 +23,13 @@
 //
 //  `sanitize(_:)` is idempotent.
 //
+//  NOTE: today the engine applies this to *already-built* Markdown, so for inputs
+//  with special characters in structurally-significant positions (a line-leading
+//  `#`/`-`, a link/image destination, a CSV cell edge) it can change Markdown
+//  structure. It is therefore opt-in — `StreamInfo.sanitizeUnicode` defaults to
+//  false. Sanitizing per converter, before Markdown is built (which would make it
+//  safe to enable by default), is a planned follow-up.
+//
 
 import Foundation
 

--- a/Sources/PicoDocs/Sanitization/UnicodeSanitizer.swift
+++ b/Sources/PicoDocs/Sanitization/UnicodeSanitizer.swift
@@ -30,25 +30,31 @@ public enum UnicodeSanitizer {
     public static func sanitize(_ string: String) -> String {
         guard !string.isEmpty else { return string }
 
-        // Normalize line endings up front so CR / CRLF fold to LF without
-        // producing extra blank lines in the scalar pass below.
-        var source = string
-        if source.contains("\r") {
-            source = source
-                .replacingOccurrences(of: "\r\n", with: "\n")
-                .replacingOccurrences(of: "\r", with: "\n")
-        }
+        // Single O(N) pass with inline carriage-return tracking, so CR, CRLF and
+        // NEL all collapse to one newline without any intermediate string copies.
+        var scalars: [Unicode.Scalar] = []
+        scalars.reserveCapacity(string.unicodeScalars.count)
+        var lastWasCarriageReturn = false
 
-        var output = ""
-        output.unicodeScalars.reserveCapacity(source.unicodeScalars.count)
-        for scalar in source.unicodeScalars {
+        for scalar in string.unicodeScalars {
+            // An LF immediately after a CR completes a CRLF; the CR already
+            // emitted the newline, so swallow this LF.
+            if lastWasCarriageReturn {
+                lastWasCarriageReturn = false
+                if scalar.value == 0x0A { continue }
+            }
+
             switch scalar.value {
-            // Keep tab and newline.
+            // CR → newline (a following LF is swallowed above).
+            case 0x0D:
+                scalars.append("\n")
+                lastWasCarriageReturn = true
+            // Keep tab and (standalone) newline.
             case 0x09, 0x0A:
-                output.unicodeScalars.append(scalar)
+                scalars.append(scalar)
             // NEL (next line) → newline.
             case 0x85:
-                output.unicodeScalars.append("\n")
+                scalars.append("\n")
             // Other C0 controls, DEL, and C1 controls → drop.
             case 0x00...0x1F, 0x7F...0x9F:
                 break
@@ -60,20 +66,20 @@ public enum UnicodeSanitizer {
                 break
             // Unicode space variants → ASCII space.
             case 0x00A0, 0x1680, 0x2000...0x200A, 0x202F, 0x205F, 0x3000:
-                output.unicodeScalars.append(" ")
+                scalars.append(" ")
             // Line / paragraph separators → newline.
             case 0x2028, 0x2029:
-                output.unicodeScalars.append("\n")
+                scalars.append("\n")
             // Replacement character (a failed decode) → drop.
             case 0xFFFD:
                 break
             default:
-                output.unicodeScalars.append(scalar)
+                scalars.append(scalar)
             }
         }
 
         // Canonical composition (NFC): combine base + combining marks, etc.
-        return output.precomposedStringWithCanonicalMapping
+        return String(String.UnicodeScalarView(scalars)).precomposedStringWithCanonicalMapping
     }
 
     /// Cleans the text-bearing fields of a `ConverterResult` — section `markdown`

--- a/Sources/PicoDocs/Sanitization/UnicodeSanitizer.swift
+++ b/Sources/PicoDocs/Sanitization/UnicodeSanitizer.swift
@@ -63,19 +63,21 @@ public enum UnicodeSanitizer {
             // Keep tab and (standalone) newline.
             case 0x09, 0x0A:
                 scalars.append(scalar)
-            // Vertical separators converters DON'T already flatten — NEL, form
-            // feed (page break), and line/paragraph separators — fold to a space.
-            // Not a newline: this pass runs after Markdown is built, so a stray
-            // newline would split table rows etc.; a space keeps the word boundary.
-            case 0x0C, 0x85, 0x2028, 0x2029:
+            // Vertical separators converters DON'T already flatten — vertical tab,
+            // form feed (page break), NEL, and line/paragraph separators — fold to
+            // a space. Not a newline: this pass runs after Markdown is built, so a
+            // stray newline would split table rows etc.; a space keeps the boundary.
+            case 0x0B, 0x0C, 0x85, 0x2028, 0x2029:
                 scalars.append(" ")
             // Other C0 controls, DEL, and C1 controls → drop.
             case 0x00...0x1F, 0x7F...0x9F:
                 break
-            // Zero-width space, word joiner, soft hyphen, BOM → drop. ZWNJ (U+200C)
-            // and ZWJ (U+200D) are intentionally kept: they shape Persian/Indic
-            // text and compose emoji (e.g. 👨‍👩‍👧‍👦), i.e. they're visible content.
-            case 0x00AD, 0x200B, 0x2060, 0xFEFF:
+            // Zero-width space, soft hyphen, BOM, word joiner + invisible math
+            // operators (U+2060–2064: word joiner, function application, invisible
+            // times/separator/plus) → drop. ZWNJ (U+200C) and ZWJ (U+200D) are
+            // intentionally kept: they shape Persian/Indic text and compose emoji
+            // (e.g. 👨‍👩‍👧‍👦), i.e. they're visible content.
+            case 0x00AD, 0x200B, 0x2060...0x2064, 0xFEFF:
                 break
             // Bidirectional formatting controls (incl. U+061C Arabic Letter Mark).
             case 0x061C, 0x200E, 0x200F, 0x202A...0x202E, 0x2066...0x2069:

--- a/Tests/PicoDocsTests/UnicodeSanitizerTests.swift
+++ b/Tests/PicoDocsTests/UnicodeSanitizerTests.swift
@@ -13,20 +13,26 @@ import Testing
 @Suite("Unicode sanitization")
 struct UnicodeSanitizerTests {
 
-    @Test("Removes zero-width and invisible formatting characters")
+    @Test("Removes truly-invisible formatting characters")
     func removesInvisibles() {
         #expect(UnicodeSanitizer.sanitize("a\u{200B}b") == "ab")            // ZWSP
-        #expect(UnicodeSanitizer.sanitize("a\u{200C}b") == "ab")            // ZWNJ
-        #expect(UnicodeSanitizer.sanitize("a\u{200D}b") == "ab")            // ZWJ
         #expect(UnicodeSanitizer.sanitize("a\u{2060}b") == "ab")            // word joiner
         #expect(UnicodeSanitizer.sanitize("\u{FEFF}text") == "text")        // BOM / ZWNBSP
         #expect(UnicodeSanitizer.sanitize("soft\u{00AD}hyphen") == "softhyphen")
+    }
+
+    @Test("Keeps ZWJ / ZWNJ joiners (they shape text and compose emoji)")
+    func keepsJoiners() {
+        #expect(UnicodeSanitizer.sanitize("a\u{200C}b") == "a\u{200C}b")    // ZWNJ kept
+        let family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}"          // 👨‍👩‍👧 (ZWJ)
+        #expect(UnicodeSanitizer.sanitize(family) == family)               // ZWJ kept
     }
 
     @Test("Removes bidirectional formatting controls")
     func removesBidi() {
         #expect(UnicodeSanitizer.sanitize("a\u{202E}b\u{202C}c") == "abc")
         #expect(UnicodeSanitizer.sanitize("a\u{2066}b\u{2069}c") == "abc")
+        #expect(UnicodeSanitizer.sanitize("a\u{061C}b") == "ab")   // Arabic letter mark
     }
 
     @Test("Folds Unicode space variants to a plain space")
@@ -36,13 +42,14 @@ struct UnicodeSanitizerTests {
         #expect(UnicodeSanitizer.sanitize("a\u{3000}b") == "a b")   // ideographic space
     }
 
-    @Test("Folds line/paragraph separators and CR/CRLF/NEL to newline")
+    @Test("Normalizes CR/CRLF to newline; folds other separators to space")
     func foldsLineBreaks() {
-        #expect(UnicodeSanitizer.sanitize("a\u{2028}b") == "a\nb")  // line separator
-        #expect(UnicodeSanitizer.sanitize("a\u{2029}b") == "a\nb")  // paragraph separator
-        #expect(UnicodeSanitizer.sanitize("a\u{0085}b") == "a\nb")  // NEL
-        #expect(UnicodeSanitizer.sanitize("a\r\nb") == "a\nb")      // CRLF
-        #expect(UnicodeSanitizer.sanitize("a\rb") == "a\nb")        // lone CR
+        #expect(UnicodeSanitizer.sanitize("a\r\nb") == "a\nb")      // CRLF → LF
+        #expect(UnicodeSanitizer.sanitize("a\rb") == "a\nb")        // lone CR → LF
+        #expect(UnicodeSanitizer.sanitize("a\u{2028}b") == "a b")   // line separator → space
+        #expect(UnicodeSanitizer.sanitize("a\u{2029}b") == "a b")   // paragraph separator → space
+        #expect(UnicodeSanitizer.sanitize("a\u{0085}b") == "a b")   // NEL → space
+        #expect(UnicodeSanitizer.sanitize("a\u{000C}b") == "a b")   // form feed → space
     }
 
     @Test("Drops control characters but keeps tab and newline")
@@ -98,5 +105,21 @@ struct UnicodeSanitizerTests {
         let scalars = result.markdown().unicodeScalars
         #expect(scalars.contains("\u{200B}"))
         #expect(scalars.contains("\u{00A0}"))
+    }
+
+    @Test("convert throws when sanitizing removes all content")
+    func engineThrowsWhenSanitizedEmpty() async throws {
+        let data = Data("\u{FEFF}\u{200B}\u{2060}".utf8)   // only removable characters
+        await #expect(throws: PicoDocsError.self) {
+            _ = try await PicoDocsEngine.convert(data: data, filename: "blank.txt")
+        }
+    }
+
+    @Test("CSV export sanitizes metadata-backed cell content")
+    func csvExportSanitized() async throws {
+        let csv = Data("a\u{200B}b,c\u{00A0}d\n1,2".utf8)
+        let out = try await PicoDocsEngine.export(data: csv, filename: "t.csv", to: .csv)
+        #expect(!out.unicodeScalars.contains("\u{200B}"))   // ZWSP removed
+        #expect(!out.unicodeScalars.contains("\u{00A0}"))   // NBSP folded to space
     }
 }

--- a/Tests/PicoDocsTests/UnicodeSanitizerTests.swift
+++ b/Tests/PicoDocsTests/UnicodeSanitizerTests.swift
@@ -1,0 +1,102 @@
+//
+//  UnicodeSanitizerTests.swift
+//  PicoDocsTests
+//
+//  Unit coverage for `UnicodeSanitizer` plus its integration into the engine
+//  (`PicoDocsEngine.convert` applies it by default, honoring `sanitizeUnicode`).
+//
+
+import Foundation
+import Testing
+@testable import PicoDocs
+
+@Suite("Unicode sanitization")
+struct UnicodeSanitizerTests {
+
+    @Test("Removes zero-width and invisible formatting characters")
+    func removesInvisibles() {
+        #expect(UnicodeSanitizer.sanitize("a\u{200B}b") == "ab")            // ZWSP
+        #expect(UnicodeSanitizer.sanitize("a\u{200C}b") == "ab")            // ZWNJ
+        #expect(UnicodeSanitizer.sanitize("a\u{200D}b") == "ab")            // ZWJ
+        #expect(UnicodeSanitizer.sanitize("a\u{2060}b") == "ab")            // word joiner
+        #expect(UnicodeSanitizer.sanitize("\u{FEFF}text") == "text")        // BOM / ZWNBSP
+        #expect(UnicodeSanitizer.sanitize("soft\u{00AD}hyphen") == "softhyphen")
+    }
+
+    @Test("Removes bidirectional formatting controls")
+    func removesBidi() {
+        #expect(UnicodeSanitizer.sanitize("a\u{202E}b\u{202C}c") == "abc")
+        #expect(UnicodeSanitizer.sanitize("a\u{2066}b\u{2069}c") == "abc")
+    }
+
+    @Test("Folds Unicode space variants to a plain space")
+    func foldsSpaces() {
+        #expect(UnicodeSanitizer.sanitize("a\u{00A0}b") == "a b")   // no-break space
+        #expect(UnicodeSanitizer.sanitize("a\u{2009}b") == "a b")   // thin space
+        #expect(UnicodeSanitizer.sanitize("a\u{3000}b") == "a b")   // ideographic space
+    }
+
+    @Test("Folds line/paragraph separators and CR/CRLF/NEL to newline")
+    func foldsLineBreaks() {
+        #expect(UnicodeSanitizer.sanitize("a\u{2028}b") == "a\nb")  // line separator
+        #expect(UnicodeSanitizer.sanitize("a\u{2029}b") == "a\nb")  // paragraph separator
+        #expect(UnicodeSanitizer.sanitize("a\u{0085}b") == "a\nb")  // NEL
+        #expect(UnicodeSanitizer.sanitize("a\r\nb") == "a\nb")      // CRLF
+        #expect(UnicodeSanitizer.sanitize("a\rb") == "a\nb")        // lone CR
+    }
+
+    @Test("Drops control characters but keeps tab and newline")
+    func dropsControls() {
+        #expect(UnicodeSanitizer.sanitize("a\u{0007}b") == "ab")    // bell
+        #expect(UnicodeSanitizer.sanitize("a\u{0000}b") == "ab")    // NUL
+        #expect(UnicodeSanitizer.sanitize("a\u{FFFD}b") == "ab")    // replacement char
+        #expect(UnicodeSanitizer.sanitize("a\tb\nc") == "a\tb\nc")  // tab + newline kept
+    }
+
+    @Test("Applies canonical (NFC) composition")
+    func canonicalComposition() {
+        let decomposed = "e\u{0301}"   // e + combining acute accent
+        let sanitized = UnicodeSanitizer.sanitize(decomposed)
+        #expect(sanitized == "é")
+        #expect(sanitized.unicodeScalars.count == 1)
+    }
+
+    @Test("Preserves legitimate visible typography")
+    func preservesTypography() {
+        // “Hello” — café…  (smart quotes, em dash, precomposed accent, ellipsis)
+        let text = "\u{201C}Hello\u{201D} \u{2014} caf\u{00E9}\u{2026}"
+        #expect(UnicodeSanitizer.sanitize(text) == text)
+    }
+
+    @Test("Is idempotent")
+    func idempotent() {
+        let messy = "\u{FEFF}a\u{200B}b\u{00A0}c\u{2028}d\r\ne\u{0301}"
+        let once = UnicodeSanitizer.sanitize(messy)
+        #expect(UnicodeSanitizer.sanitize(once) == once)
+    }
+
+    @Test("Empty string is unchanged")
+    func emptyString() {
+        #expect(UnicodeSanitizer.sanitize("") == "")
+    }
+
+    // MARK: - Engine integration
+
+    @Test("convert sanitizes extracted text by default")
+    func engineSanitizesByDefault() async throws {
+        let data = Data("Hello\u{200B}\u{00A0}World".utf8)
+        let result = try await PicoDocsEngine.convert(data: data, filename: "note.txt")
+        #expect(result.markdown() == "Hello World")
+    }
+
+    @Test("convert leaves text untouched when sanitizeUnicode is false")
+    func engineRespectsOptOut() async throws {
+        let data = Data("Hello\u{200B}\u{00A0}World".utf8)
+        let result = try await PicoDocsEngine.convert(
+            data: data, filename: "note.txt", sanitizeUnicode: false
+        )
+        let scalars = result.markdown().unicodeScalars
+        #expect(scalars.contains("\u{200B}"))
+        #expect(scalars.contains("\u{00A0}"))
+    }
+}

--- a/Tests/PicoDocsTests/UnicodeSanitizerTests.swift
+++ b/Tests/PicoDocsTests/UnicodeSanitizerTests.swift
@@ -89,36 +89,40 @@ struct UnicodeSanitizerTests {
 
     // MARK: - Engine integration
 
-    @Test("convert sanitizes extracted text by default")
-    func engineSanitizesByDefault() async throws {
+    @Test("convert leaves text raw by default (sanitization is opt-in)")
+    func engineDefaultsToRaw() async throws {
         let data = Data("Hello\u{200B}\u{00A0}World".utf8)
         let result = try await PicoDocsEngine.convert(data: data, filename: "note.txt")
-        #expect(result.markdown() == "Hello World")
-    }
-
-    @Test("convert leaves text untouched when sanitizeUnicode is false")
-    func engineRespectsOptOut() async throws {
-        let data = Data("Hello\u{200B}\u{00A0}World".utf8)
-        let result = try await PicoDocsEngine.convert(
-            data: data, filename: "note.txt", sanitizeUnicode: false
-        )
         let scalars = result.markdown().unicodeScalars
         #expect(scalars.contains("\u{200B}"))
         #expect(scalars.contains("\u{00A0}"))
     }
 
-    @Test("convert throws when sanitizing removes all content")
+    @Test("convert sanitizes when sanitizeUnicode is enabled")
+    func engineSanitizesWhenEnabled() async throws {
+        let data = Data("Hello\u{200B}\u{00A0}World".utf8)
+        let result = try await PicoDocsEngine.convert(
+            data: data, filename: "note.txt", sanitizeUnicode: true
+        )
+        #expect(result.markdown() == "Hello World")
+    }
+
+    @Test("convert throws when enabled sanitization removes all content")
     func engineThrowsWhenSanitizedEmpty() async throws {
         let data = Data("\u{FEFF}\u{200B}\u{2060}".utf8)   // only removable characters
         await #expect(throws: PicoDocsError.self) {
-            _ = try await PicoDocsEngine.convert(data: data, filename: "blank.txt")
+            _ = try await PicoDocsEngine.convert(
+                data: data, filename: "blank.txt", sanitizeUnicode: true
+            )
         }
     }
 
-    @Test("CSV export sanitizes metadata-backed cell content")
+    @Test("CSV export sanitizes metadata-backed cell content when enabled")
     func csvExportSanitized() async throws {
         let csv = Data("a\u{200B}b,c\u{00A0}d\n1,2".utf8)
-        let out = try await PicoDocsEngine.export(data: csv, filename: "t.csv", to: .csv)
+        let out = try await PicoDocsEngine.export(
+            data: csv, filename: "t.csv", to: .csv, sanitizeUnicode: true
+        )
         #expect(!out.unicodeScalars.contains("\u{200B}"))   // ZWSP removed
         #expect(!out.unicodeScalars.contains("\u{00A0}"))   // NBSP folded to space
     }

--- a/Tests/PicoDocsTests/UnicodeSanitizerTests.swift
+++ b/Tests/PicoDocsTests/UnicodeSanitizerTests.swift
@@ -17,6 +17,8 @@ struct UnicodeSanitizerTests {
     func removesInvisibles() {
         #expect(UnicodeSanitizer.sanitize("a\u{200B}b") == "ab")            // ZWSP
         #expect(UnicodeSanitizer.sanitize("a\u{2060}b") == "ab")            // word joiner
+        #expect(UnicodeSanitizer.sanitize("a\u{2062}b") == "ab")            // invisible times
+        #expect(UnicodeSanitizer.sanitize("a\u{2064}b") == "ab")            // invisible plus
         #expect(UnicodeSanitizer.sanitize("\u{FEFF}text") == "text")        // BOM / ZWNBSP
         #expect(UnicodeSanitizer.sanitize("soft\u{00AD}hyphen") == "softhyphen")
     }
@@ -50,6 +52,7 @@ struct UnicodeSanitizerTests {
         #expect(UnicodeSanitizer.sanitize("a\u{2029}b") == "a b")   // paragraph separator → space
         #expect(UnicodeSanitizer.sanitize("a\u{0085}b") == "a b")   // NEL → space
         #expect(UnicodeSanitizer.sanitize("a\u{000C}b") == "a b")   // form feed → space
+        #expect(UnicodeSanitizer.sanitize("a\u{000B}b") == "a b")   // vertical tab → space
     }
 
     @Test("Drops control characters but keeps tab and newline")


### PR DESCRIPTION
## What & why

Second slice of the roadmap (OCR ✅ → **Unicode sanitization** → Pages → Keynote → Numbers). Extracted text from real-world documents is full of invisible/control junk — zero-width spaces, BOMs, bidi controls, non-breaking spaces, soft hyphens, stray control chars, decode-failure `U+FFFD`, mixed line endings, and decomposed accents — which hurts tokenization, embedding/retrieval quality, and diffing. This adds a conservative cleanup pass.

## Changes

- **`UnicodeSanitizer`** — conservative, **non-lossy** cleanup:
  - canonical **NFC** normalization (not lossy NFKC, so ligatures / full-width forms survive),
  - removes invisibles (zero-width space, word joiner + invisible math operators `U+2060–2064`, soft hyphen, BOM), bidi controls (incl. `U+061C`), other C0/C1 controls, and `U+FFFD`,
  - **keeps ZWJ/ZWNJ** (they shape Persian/Indic text and compose emoji),
  - normalizes CR/CRLF/LF → newline; folds the other vertical separators (NEL, form feed, vertical tab, line/paragraph separators) **and** Unicode space variants → a plain space (never injects a newline into built Markdown),
  - **preserves visible typography** (smart quotes, dashes, ellipses, accents). Idempotent.
- **`sanitizeUnicode` flag** threaded through `StreamInfo`, `convert`/`export`, and `PicoDocument.parse` (mirrors `enableOCR`). Applied centrally in `PicoDocsEngine.convert` to section `markdown`/`title`, non-image `metadata`, and document `title`/`author`; image byte-carrier metadata / `cover` left untouched.

## ⚠️ Opt-in (default `false`)

The pass currently runs on **already-built Markdown**, so for inputs with special characters in structurally-significant positions (a line-leading `#`/`-`, a link/image destination, a CSV cell edge) it can alter Markdown structure. It's therefore **opt-in** (`sanitizeUnicode: true`) and documented as such. The robust fix — sanitizing each converter's text **before** Markdown is built (skipping `href`/`src` destinations), which is safe to enable by default — is a planned **follow-up PR**. Open review threads tagged "Deferred" track those cases.

## Testing

`UnicodeSanitizerTests` (portable, no platform gating): every transform (invisibles, ZWJ/ZWNJ kept, bidi, space/separator folding, control removal, NFC), typography preservation, idempotence, empty input, plus engine integration (raw by default; sanitized + empty-on-removal + CSV-export when enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mxnj6jvuLX9VS9JsJJbjmf