### PR TITLE
Add Apple Pages (.pages) converter via in-module IWA decoding

### DIFF
--- a/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
+++ b/Sources/PicoDocs/Converters/DocumentConverterRegistry.swift
@@ -56,6 +56,7 @@ public struct DocumentConverterRegistry: Sendable {
             .registering(WordConverter(), priority: Priority.specific)
             .registering(RTFConverter(), priority: Priority.specific)
             .registering(CSVConverter(), priority: Priority.specific)
+            .registering(PagesConverter(), priority: Priority.specific)
         #if canImport(PDFKit)
         registry = registry.registering(PDFConverter(), priority: Priority.specific)
         #endif

--- a/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
@@ -37,17 +37,19 @@ enum IWAArchive {
         var objects: [Object] = []
         var cursor = StreamCursor(stream)
         while let archiveLen = cursor.readVarint() {
-            guard archiveLen > 0, let archiveBytes = cursor.take(Int(archiveLen)) else { break }
+            guard archiveLen > 0, archiveLen <= UInt64(Int.max),
+                  let archiveBytes = cursor.take(Int(archiveLen)) else { break }
             let infos = messageInfos(in: archiveBytes)
             guard !infos.isEmpty else { break }
             // Payloads follow the ArchiveInfo, concatenated in MessageInfo order.
-            var tookAny = false
+            // Stop at the first failure (truncated/garbled stream, or a length past
+            // `Int.max`) and return what parsed cleanly — never re-read past a
+            // partially-consumed object, which would mis-parse or loop.
             for info in infos {
-                guard let payload = cursor.take(Int(info.length)) else { break }
+                guard info.length <= UInt64(Int.max),
+                      let payload = cursor.take(Int(info.length)) else { return objects }
                 objects.append(Object(identifier: info.identifier, type: info.type, payload: payload))
-                tookAny = true
             }
-            if !tookAny { break }
         }
         return objects
     }

--- a/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
@@ -168,7 +168,9 @@ private struct StreamCursor {
     }
 
     mutating func take(_ count: Int) -> [UInt8]? {
-        guard count >= 0, pos + count <= bytes.count else { return nil }
+        // `count <= bytes.count - pos` rather than `pos + count <= count` so a
+        // hostile length near Int.max can't overflow the addition.
+        guard count >= 0, count <= bytes.count - pos else { return nil }
         let slice = Array(bytes[pos ..< pos + count])
         pos += count
         return slice

--- a/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
@@ -38,7 +38,12 @@ enum IWAArchive {
         let payload: [UInt8]
     }
 
-    /// Parses every object in a decompressed IWA stream.
+    /// Parses every object in a decompressed IWA stream. Best-effort: on a
+    /// truncated/garbled envelope it returns the objects parsed so far rather than
+    /// throwing, so partially-recoverable files still yield text. Strict
+    /// envelope-truncation detection (failing on any malformation) is deferred to
+    /// the real-file-validation follow-up, to avoid mis-rejecting valid documents
+    /// whose envelope quirks aren't yet covered by tests.
     static func objects(in stream: [UInt8]) -> [Object] {
         var objects: [Object] = []
         var cursor = StreamCursor(stream)
@@ -148,10 +153,16 @@ private struct StreamCursor {
         while pos < bytes.count {
             let byte = bytes[pos]
             pos += 1
+            // Reject overflow before shifting: at the 10th byte (shift 63) only the
+            // low bit fits a 64-bit value; a longer varint is malformed.
+            if shift == 63 {
+                if byte & 0x7E != 0 { return nil }
+            } else if shift >= 64 {
+                return nil
+            }
             result |= UInt64(byte & 0x7F) << shift
             if byte & 0x80 == 0 { return result }
             shift += 7
-            if shift >= 64 { return nil }
         }
         return nil
     }

--- a/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
@@ -68,6 +68,12 @@ enum IWAArchive {
     /// Concatenated plain text from all TSWP text storages in the stream, in
     /// object order. Each storage's `repeated string text` runs are joined; a
     /// blank line separates distinct storages (body, header/footer, footnotes…).
+    ///
+    /// NOTE: this includes *all* type-2001 storages rather than filtering to body
+    /// storages via `StorageArchive.kind` (field 1). The KindType enum values
+    /// aren't verified against a real Pages file, and filtering on a wrong value
+    /// would drop real body text; confirming `kind` (and the alternate id 2005)
+    /// against a real fixture is part of the real-file-validation follow-up.
     static func text(in stream: [UInt8]) -> String {
         var storages: [String] = []
         for object in objects(in: stream) where object.type == textStorageType {

--- a/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
@@ -1,0 +1,157 @@
+//
+//  IWAArchive.swift
+//  PicoDocs
+//
+//  Walks a decompressed IWA object stream into (identifier, type, payload)
+//  objects, and pulls plain text out of TSWP text storages.
+//
+//  Stream layout (after Snappy), repeated for each object:
+//      varint(ArchiveInfo length) · ArchiveInfo · payload bytes
+//  where
+//      ArchiveInfo { uint64 identifier = 1; repeated MessageInfo message_infos = 2 }
+//      MessageInfo { uint32 type = 1; uint32 length = 3 }   (other fields ignored)
+//  The payload(s) follow the ArchiveInfo, one per MessageInfo, each `length`
+//  bytes long. In practice iWork emits a single message per archive.
+//
+//  Format references: obriensp/iWorkFileFormat, the SheetJS IWA notes, and
+//  Cocoanetics/SwiftText (MIT).
+//
+
+import Foundation
+
+enum IWAArchive {
+
+    /// The TSWP text storage message type. Its field 3 is `repeated string text` —
+    /// the document's paragraph text runs. Shared across Pages/Numbers/Keynote.
+    static let textStorageType: UInt64 = 2001
+    static let textRunsField = 3
+
+    struct Object {
+        let identifier: UInt64
+        let type: UInt64
+        let payload: [UInt8]
+    }
+
+    /// Parses every object in a decompressed IWA stream.
+    static func objects(in stream: [UInt8]) -> [Object] {
+        var objects: [Object] = []
+        var cursor = StreamCursor(stream)
+        while let archiveLen = cursor.readVarint() {
+            guard archiveLen > 0, let archiveBytes = cursor.take(Int(archiveLen)) else { break }
+            let infos = messageInfos(in: archiveBytes)
+            guard !infos.isEmpty else { break }
+            // Payloads follow the ArchiveInfo, concatenated in MessageInfo order.
+            var tookAny = false
+            for info in infos {
+                guard let payload = cursor.take(Int(info.length)) else { break }
+                objects.append(Object(identifier: info.identifier, type: info.type, payload: payload))
+                tookAny = true
+            }
+            if !tookAny { break }
+        }
+        return objects
+    }
+
+    /// Concatenated plain text from all TSWP text storages in the stream, in
+    /// object order. Each storage's `repeated string text` runs are joined; a
+    /// blank line separates distinct storages (body, header/footer, footnotes…).
+    static func text(in stream: [UInt8]) -> String {
+        var storages: [String] = []
+        for object in objects(in: stream) where object.type == textStorageType {
+            let joined = textRuns(in: object.payload).joined()
+            if !joined.isEmpty { storages.append(joined) }
+        }
+        return storages.joined(separator: "\n\n")
+    }
+
+    // MARK: - Helpers
+
+    private struct InfoEntry {
+        let identifier: UInt64
+        let type: UInt64
+        let length: UInt64
+    }
+
+    /// Reads ArchiveInfo: identifier (field 1) + each MessageInfo (field 2) into
+    /// (identifier, type, length) entries.
+    private static func messageInfos(in archiveBytes: [UInt8]) -> [InfoEntry] {
+        var identifier: UInt64 = 0
+        var entries: [InfoEntry] = []
+        var reader = ProtobufReader(archiveBytes)
+        while let field = reader.next() {
+            switch (field.number, field.value) {
+            case (1, .varint(let id)):
+                identifier = id
+            case (2, .length(let messageInfoBytes)):
+                if let (type, length) = parseMessageInfo(messageInfoBytes) {
+                    entries.append(InfoEntry(identifier: identifier, type: type, length: length))
+                }
+            default:
+                continue
+            }
+        }
+        return entries
+    }
+
+    /// MessageInfo: type (field 1) + payload length (field 3).
+    private static func parseMessageInfo(_ bytes: [UInt8]) -> (type: UInt64, length: UInt64)? {
+        var type: UInt64?
+        var length: UInt64?
+        var reader = ProtobufReader(bytes)
+        while let field = reader.next() {
+            switch (field.number, field.value) {
+            case (1, .varint(let t)): type = t
+            case (3, .varint(let l)): length = l
+            default: continue
+            }
+        }
+        guard let type, let length else { return nil }
+        return (type, length)
+    }
+
+    /// TSWP.StorageArchive: field 3 is `repeated string text`. Returns the runs in
+    /// order (concatenation reconstructs the storage's full text).
+    private static func textRuns(in payload: [UInt8]) -> [String] {
+        var runs: [String] = []
+        var reader = ProtobufReader(payload)
+        while let field = reader.next() {
+            if field.number == textRunsField, case .length(let bytes) = field.value,
+               let run = String(bytes: bytes, encoding: .utf8) {
+                runs.append(run)
+            }
+        }
+        return runs
+    }
+}
+
+/// Raw varint + slice cursor over the decompressed object stream (the IWA
+/// envelope is read by hand rather than via `ProtobufReader`, which decodes
+/// whole messages).
+private struct StreamCursor {
+    private let bytes: [UInt8]
+    private var pos: Int = 0
+
+    init(_ bytes: [UInt8]) { self.bytes = bytes }
+
+    mutating func readVarint() -> UInt64? {
+        guard pos < bytes.count else { return nil }
+        var result: UInt64 = 0
+        var shift: UInt64 = 0
+        while pos < bytes.count {
+            let byte = bytes[pos]
+            pos += 1
+            result |= UInt64(byte & 0x7F) << shift
+            if byte & 0x80 == 0 { return result }
+            shift += 7
+            if shift >= 64 { return nil }
+        }
+        return nil
+    }
+
+    mutating func take(_ count: Int) -> [UInt8]? {
+        guard count >= 0, pos + count <= bytes.count else { return nil }
+        let slice = Array(bytes[pos ..< pos + count])
+        pos += count
+        return slice
+    }
+}

--- a/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
@@ -21,8 +21,14 @@ import Foundation
 
 enum IWAArchive {
 
-    /// The TSWP text storage message type. Its field 3 is `repeated string text` —
-    /// the document's paragraph text runs. Shared across Pages/Numbers/Keynote.
+    /// The TSWP text storage message type (`TSWP.StorageArchive`). Its field 3 is
+    /// `repeated string text` — the document's paragraph text runs. Shared across
+    /// Pages/Numbers/Keynote.
+    ///
+    /// Only the well-established id 2001 is matched. Other ids occasionally cited
+    /// for text storage (e.g. 2005) are deliberately not included until confirmed
+    /// against a real Pages file / the type registry — a wrong id would surface
+    /// non-text payloads as garbage. Revisit with the real-file fixture follow-up.
     static let textStorageType: UInt64 = 2001
     static let textRunsField = 3
 

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -8,10 +8,13 @@
 //  `Index/*.iwa` (or a nested `Index.zip`); each `.iwa` is a Snappy-framed
 //  protobuf object stream whose TSWP text storages carry the body text.
 //
-//  Scope (v1): extracts the document's plain text (paragraphs). Rich structure —
-//  headings, styling, tables, footnotes, inline images — and the legacy iWork
-//  '09 XML format are planned follow-ups; this converter raises a clear,
-//  actionable error for inputs it can't yet read rather than emitting nothing.
+//  Scope (v1): extracts the document's plain text (paragraphs) from the flat,
+//  single-file `.pages` ZIP — the common transport form (downloads, mail, Files
+//  exports). Rich structure (headings, styling, tables, footnotes, inline
+//  images), the legacy iWork '09 XML format, and ingesting a `.pages` *package
+//  directory* (an on-disk bundle, which the FileFetcher currently treats as a
+//  folder) are planned follow-ups; this converter raises a clear, actionable
+//  error for inputs it can't yet read rather than emitting nothing.
 //
 //  Format references: obriensp/iWorkFileFormat, the SheetJS IWA notes, and
 //  Cocoanetics/SwiftText (MIT) — the in-module decode approach here is informed
@@ -48,7 +51,17 @@ public struct PagesConverter: DocumentConverter {
         var bodyText = ""
         for component in orderedForText(components) {
             try Task.checkCancellation()
-            guard let stream = try? Snappy.decompressIWA(component.bytes) else { continue }
+            let isMainStory = component.name.hasSuffix("Document.iwa")
+            let stream: [UInt8]
+            do {
+                stream = try Snappy.decompressIWA(component.bytes)
+            } catch {
+                // A corrupt main story is real corruption — fail rather than
+                // silently fall back to auxiliary components and report partial or
+                // non-body text as a successful conversion.
+                if isMainStory { throw PicoDocsError.fileCorrupted }
+                continue
+            }
             let extracted = IWAArchive.text(in: stream)
             if !extracted.isEmpty {
                 bodyText = extracted

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -46,26 +46,28 @@ public struct PagesConverter: DocumentConverter {
             throw PicoDocsError.documentTypeNotSupported
         }
 
-        // The main story lives in Document.iwa; prefer it to avoid pulling in
-        // stylesheet/template text, falling back to other components if absent.
+        // The main story lives in Document.iwa and is authoritative: if present it
+        // must decompress cleanly (corruption → fail), and its text — even if
+        // empty — determines the result, so we never scavenge stylesheet/header
+        // text from auxiliary components and pass it off as the body. Only when
+        // Document.iwa is absent do we fall back to a best-effort scan.
         var bodyText = ""
-        for component in orderedForText(components) {
+        if let main = components.first(where: { $0.name.hasSuffix("Document.iwa") }) {
             try Task.checkCancellation()
-            let isMainStory = component.name.hasSuffix("Document.iwa")
-            let stream: [UInt8]
             do {
-                stream = try Snappy.decompressIWA(component.bytes)
+                bodyText = IWAArchive.text(in: try Snappy.decompressIWA(main.bytes))
             } catch {
-                // A corrupt main story is real corruption — fail rather than
-                // silently fall back to auxiliary components and report partial or
-                // non-body text as a successful conversion.
-                if isMainStory { throw PicoDocsError.fileCorrupted }
-                continue
+                throw PicoDocsError.fileCorrupted
             }
-            let extracted = IWAArchive.text(in: stream)
-            if !extracted.isEmpty {
-                bodyText = extracted
-                break
+        } else {
+            for component in components.sorted(by: { $0.name < $1.name }) {
+                try Task.checkCancellation()
+                guard let stream = try? Snappy.decompressIWA(component.bytes) else { continue }
+                let extracted = IWAArchive.text(in: stream)
+                if !extracted.isEmpty {
+                    bodyText = extracted
+                    break
+                }
             }
         }
 
@@ -103,8 +105,14 @@ public struct PagesConverter: DocumentConverter {
         }
         if !components.isEmpty { return components }
 
-        if let indexZip = Self.readEntry(archive, path: "Index.zip"),
-           let inner = Archive(data: indexZip, accessMode: .read) {
+        // Nested layout: the IWA streams live inside Index.zip. If that container
+        // is present but can't be read/opened, the file is corrupt — not an
+        // unsupported layout — so surface that distinctly.
+        if archive["Index.zip"] != nil {
+            guard let indexZip = Self.readEntry(archive, path: "Index.zip"),
+                  let inner = Archive(data: indexZip, accessMode: .read) else {
+                throw PicoDocsError.fileCorrupted
+            }
             for entry in inner where entry.type == .file && entry.path.hasSuffix(".iwa") {
                 guard let data = Self.readEntry(inner, path: entry.path) else {
                     if entry.path.hasSuffix("Document.iwa") { throw PicoDocsError.fileCorrupted }
@@ -114,16 +122,6 @@ public struct PagesConverter: DocumentConverter {
             }
         }
         return components
-    }
-
-    /// Puts `Document.iwa` first (the main text story); stable order otherwise.
-    private func orderedForText(_ components: [Component]) -> [Component] {
-        components.sorted { lhs, rhs in
-            let l = lhs.name.hasSuffix("Document.iwa")
-            let r = rhs.name.hasSuffix("Document.iwa")
-            if l != r { return l }
-            return lhs.name < rhs.name
-        }
     }
 
     // MARK: - Text normalization

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -39,7 +39,7 @@ public struct PagesConverter: DocumentConverter {
 
         // Gather the IWA component streams. Two common on-disk layouts: loose
         // `Index/*.iwa` entries, or a nested `Index.zip` containing them.
-        let components = iwaComponents(in: archive)
+        let components = try iwaComponents(in: archive)
         guard !components.isEmpty else {
             // Likely a legacy iWork '09 package (index.xml[.gz]) or an unexpected
             // layout — not supported yet.
@@ -89,22 +89,28 @@ public struct PagesConverter: DocumentConverter {
     }
 
     /// Reads the `.iwa` component streams from loose `Index/*.iwa` entries, or —
-    /// failing that — from a nested `Index.zip`.
-    private func iwaComponents(in archive: Archive) -> [Component] {
+    /// failing that — from a nested `Index.zip`. A present-but-unreadable main
+    /// story (`Document.iwa`) is treated as corruption; auxiliary entries that
+    /// fail to extract are skipped leniently.
+    private func iwaComponents(in archive: Archive) throws -> [Component] {
         var components: [Component] = []
         for entry in archive where entry.type == .file && entry.path.hasSuffix(".iwa") {
-            if let data = Self.readEntry(archive, path: entry.path) {
-                components.append(Component(name: entry.path, bytes: [UInt8](data)))
+            guard let data = Self.readEntry(archive, path: entry.path) else {
+                if entry.path.hasSuffix("Document.iwa") { throw PicoDocsError.fileCorrupted }
+                continue
             }
+            components.append(Component(name: entry.path, bytes: [UInt8](data)))
         }
         if !components.isEmpty { return components }
 
         if let indexZip = Self.readEntry(archive, path: "Index.zip"),
            let inner = Archive(data: indexZip, accessMode: .read) {
             for entry in inner where entry.type == .file && entry.path.hasSuffix(".iwa") {
-                if let data = Self.readEntry(inner, path: entry.path) {
-                    components.append(Component(name: entry.path, bytes: [UInt8](data)))
+                guard let data = Self.readEntry(inner, path: entry.path) else {
+                    if entry.path.hasSuffix("Document.iwa") { throw PicoDocsError.fileCorrupted }
+                    continue
                 }
+                components.append(Component(name: entry.path, bytes: [UInt8](data)))
             }
         }
         return components

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -96,7 +96,10 @@ public struct PagesConverter: DocumentConverter {
     /// fail to extract are skipped leniently.
     private func iwaComponents(in archive: Archive) throws -> [Component] {
         var components: [Component] = []
-        for entry in archive where entry.type == .file && entry.path.hasSuffix(".iwa") {
+        // Loose layout is `Index/*.iwa`; scope the scan to that path so a stray
+        // outer `.iwa` can't shadow the nested `Index.zip` body below.
+        for entry in archive where entry.type == .file
+            && entry.path.hasPrefix("Index/") && entry.path.hasSuffix(".iwa") {
             guard let data = Self.readEntry(archive, path: entry.path) else {
                 if entry.path.hasSuffix("Document.iwa") { throw PicoDocsError.fileCorrupted }
                 continue
@@ -154,7 +157,9 @@ public struct PagesConverter: DocumentConverter {
     static func readEntry(_ archive: Archive, path: String) -> Data? {
         let cleanPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
         guard let entry = archive[cleanPath] else { return nil }
-        var data = Data(capacity: Int(entry.uncompressedSize))
+        // Cap the reservation hint: `uncompressedSize` is untrusted central-
+        // directory data, only validated during extract.
+        var data = Data(capacity: min(Int(entry.uncompressedSize), 16 * 1024 * 1024))
         do {
             _ = try archive.extract(entry) { data.append($0) }
         } catch {

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -116,10 +116,11 @@ public struct PagesConverter: DocumentConverter {
         for separator in ["\r\n", "\r", "\u{2028}", "\u{2029}", "\u{000B}", "\u{000C}"] {
             unified = unified.replacingOccurrences(of: separator, with: "\n")
         }
+        let inlineWhitespace = CharacterSet(charactersIn: " \t")
         var out: [String] = []
         var pendingBlank = false
         for rawLine in unified.components(separatedBy: "\n") {
-            let line = rawLine.trimmingCharacters(in: CharacterSet(charactersIn: " \t"))
+            let line = rawLine.trimmingCharacters(in: inlineWhitespace)
             if line.isEmpty {
                 pendingBlank = true
             } else {

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -1,0 +1,147 @@
+//
+//  PagesConverter.swift
+//  PicoDocs
+//
+//  Converts modern Apple Pages (`.pages`, iWork '13+) documents to Markdown by
+//  decoding the iWork Archive (IWA) format in-module — no Pages.app, no Apple
+//  frameworks, no protobuf/snappy dependency. The package is a ZIP holding
+//  `Index/*.iwa` (or a nested `Index.zip`); each `.iwa` is a Snappy-framed
+//  protobuf object stream whose TSWP text storages carry the body text.
+//
+//  Scope (v1): extracts the document's plain text (paragraphs). Rich structure —
+//  headings, styling, tables, footnotes, inline images — and the legacy iWork
+//  '09 XML format are planned follow-ups; this converter raises a clear,
+//  actionable error for inputs it can't yet read rather than emitting nothing.
+//
+//  Format references: obriensp/iWorkFileFormat, the SheetJS IWA notes, and
+//  Cocoanetics/SwiftText (MIT) — the in-module decode approach here is informed
+//  by SwiftText's SwiftTextPages module.
+//
+
+import Foundation
+import ZIPFoundation
+
+public struct PagesConverter: DocumentConverter {
+
+    public init() {}
+
+    public func accepts(_ info: StreamInfo) -> Bool {
+        info.detectedFormat == .pages
+    }
+
+    public func convert(_ data: Data, info: StreamInfo) async throws -> ConverterResult {
+        guard let archive = Archive(data: data, accessMode: .read) else {
+            throw PicoDocsError.fileCorrupted
+        }
+
+        // Gather the IWA component streams. Two common on-disk layouts: loose
+        // `Index/*.iwa` entries, or a nested `Index.zip` containing them.
+        let components = iwaComponents(in: archive)
+        guard !components.isEmpty else {
+            // Likely a legacy iWork '09 package (index.xml[.gz]) or an unexpected
+            // layout — not supported yet.
+            throw PicoDocsError.documentTypeNotSupported
+        }
+
+        // The main story lives in Document.iwa; prefer it to avoid pulling in
+        // stylesheet/template text, falling back to other components if absent.
+        var bodyText = ""
+        for component in orderedForText(components) {
+            try Task.checkCancellation()
+            guard let stream = try? Snappy.decompressIWA(component.bytes) else { continue }
+            let extracted = IWAArchive.text(in: stream)
+            if !extracted.isEmpty {
+                bodyText = extracted
+                break
+            }
+        }
+
+        let cleaned = Self.normalize(bodyText)
+        guard !cleaned.isEmpty else { throw PicoDocsError.emptyDocument }
+
+        let section = DocumentSection(
+            kind: .body,
+            markdown: cleaned,
+            sourcePath: "Index/Document.iwa"
+        )
+        let title = (info.filename?.isEmpty == false) ? info.filename : nil
+        return ConverterResult(title: title, sections: [section])
+    }
+
+    // MARK: - IWA gathering
+
+    private struct Component {
+        let name: String
+        let bytes: [UInt8]
+    }
+
+    /// Reads the `.iwa` component streams from loose `Index/*.iwa` entries, or —
+    /// failing that — from a nested `Index.zip`.
+    private func iwaComponents(in archive: Archive) -> [Component] {
+        var components: [Component] = []
+        for entry in archive where entry.type == .file && entry.path.hasSuffix(".iwa") {
+            if let data = Self.readEntry(archive, path: entry.path) {
+                components.append(Component(name: entry.path, bytes: [UInt8](data)))
+            }
+        }
+        if !components.isEmpty { return components }
+
+        if let indexZip = Self.readEntry(archive, path: "Index.zip"),
+           let inner = Archive(data: indexZip, accessMode: .read) {
+            for entry in inner where entry.type == .file && entry.path.hasSuffix(".iwa") {
+                if let data = Self.readEntry(inner, path: entry.path) {
+                    components.append(Component(name: entry.path, bytes: [UInt8](data)))
+                }
+            }
+        }
+        return components
+    }
+
+    /// Puts `Document.iwa` first (the main text story); stable order otherwise.
+    private func orderedForText(_ components: [Component]) -> [Component] {
+        components.sorted { lhs, rhs in
+            let l = lhs.name.hasSuffix("Document.iwa")
+            let r = rhs.name.hasSuffix("Document.iwa")
+            if l != r { return l }
+            return lhs.name < rhs.name
+        }
+    }
+
+    // MARK: - Text normalization
+
+    /// Folds iWork's line/paragraph separators to `\n`, trims each line, and
+    /// collapses runs of blank lines so the body reads as clean paragraphs.
+    static func normalize(_ text: String) -> String {
+        var unified = text
+        for separator in ["\r\n", "\r", "\u{2028}", "\u{2029}", "\u{000B}", "\u{000C}"] {
+            unified = unified.replacingOccurrences(of: separator, with: "\n")
+        }
+        var out: [String] = []
+        var pendingBlank = false
+        for rawLine in unified.components(separatedBy: "\n") {
+            let line = rawLine.trimmingCharacters(in: CharacterSet(charactersIn: " \t"))
+            if line.isEmpty {
+                pendingBlank = true
+            } else {
+                if pendingBlank && !out.isEmpty { out.append("") }
+                pendingBlank = false
+                out.append(line)
+            }
+        }
+        return out.joined(separator: "\n")
+    }
+
+    // MARK: - ZIP helper
+
+    static func readEntry(_ archive: Archive, path: String) -> Data? {
+        let cleanPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
+        guard let entry = archive[cleanPath] else { return nil }
+        var data = Data(capacity: Int(entry.uncompressedSize))
+        do {
+            _ = try archive.extract(entry) { data.append($0) }
+        } catch {
+            return nil
+        }
+        return data
+    }
+}

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -158,8 +158,10 @@ public struct PagesConverter: DocumentConverter {
         let cleanPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
         guard let entry = archive[cleanPath] else { return nil }
         // Cap the reservation hint: `uncompressedSize` is untrusted central-
-        // directory data, only validated during extract.
-        var data = Data(capacity: min(Int(entry.uncompressedSize), 16 * 1024 * 1024))
+        // directory data, only validated during extract. Clamp in UInt64 before
+        // the Int cast so a ZIP64 size > Int.max can't trap.
+        let reserve = Int(min(UInt64(entry.uncompressedSize), 16 * 1024 * 1024))
+        var data = Data(capacity: reserve)
         do {
             _ = try archive.extract(entry) { data.append($0) }
         } catch {

--- a/Sources/PicoDocs/Converters/Pages/ProtobufReader.swift
+++ b/Sources/PicoDocs/Converters/Pages/ProtobufReader.swift
@@ -76,10 +76,16 @@ struct ProtobufReader {
         while pos < end {
             let byte = bytes[pos]
             pos += 1
+            // Reject overflow before shifting: at the 10th byte (shift 63) only the
+            // low bit fits a 64-bit value; a longer varint is malformed.
+            if shift == 63 {
+                if byte & 0x7E != 0 { return nil }
+            } else if shift >= 64 {
+                return nil
+            }
             result |= UInt64(byte & 0x7F) << shift
             if byte & 0x80 == 0 { return result }
             shift += 7
-            if shift >= 64 { return nil }
         }
         return nil
     }

--- a/Sources/PicoDocs/Converters/Pages/ProtobufReader.swift
+++ b/Sources/PicoDocs/Converters/Pages/ProtobufReader.swift
@@ -57,7 +57,9 @@ struct ProtobufReader {
             // malformed/hostile input).
             guard let len = readVarint(), len <= UInt64(Int.max) else { return nil }
             let length = Int(len)
-            guard pos + length <= end else { return nil }
+            // Compare against remaining bytes, not `pos + length`, which can
+            // overflow/trap for a hostile length near Int.max.
+            guard length <= end - pos else { return nil }
             let sub = Array(bytes[pos ..< pos + length])
             pos += length
             return Field(number: number, value: .length(sub))

--- a/Sources/PicoDocs/Converters/Pages/ProtobufReader.swift
+++ b/Sources/PicoDocs/Converters/Pages/ProtobufReader.swift
@@ -53,9 +53,11 @@ struct ProtobufReader {
             guard let v = readFixed(8) else { return nil }
             return Field(number: number, value: .fixed64(v))
         case 2:
-            guard let len = readVarint() else { return nil }
+            // Reject lengths past `Int.max` before casting (avoids a trap on
+            // malformed/hostile input).
+            guard let len = readVarint(), len <= UInt64(Int.max) else { return nil }
             let length = Int(len)
-            guard length >= 0, pos + length <= end else { return nil }
+            guard pos + length <= end else { return nil }
             let sub = Array(bytes[pos ..< pos + length])
             pos += length
             return Field(number: number, value: .length(sub))

--- a/Sources/PicoDocs/Converters/Pages/ProtobufReader.swift
+++ b/Sources/PicoDocs/Converters/Pages/ProtobufReader.swift
@@ -1,0 +1,94 @@
+//
+//  ProtobufReader.swift
+//  PicoDocs
+//
+//  A tiny protobuf *wire-format* reader — just enough to walk iWork's IWA
+//  messages without the proprietary `.proto` schemas. We never model full message
+//  types: the IWA envelope (`ArchiveInfo` / `MessageInfo`) and the text storage
+//  (`TSWP.StorageArchive`) are read by field number alone.
+//
+//  Wire types handled: varint (0), 64-bit (1), length-delimited (2), 32-bit (5).
+//  Groups (3/4, deprecated) end iteration. The reader is best-effort: malformed
+//  input stops iteration (returns nil) rather than throwing, so one odd field
+//  can't abort a whole document.
+//
+
+import Foundation
+
+struct ProtobufReader {
+
+    enum Value: Equatable {
+        case varint(UInt64)
+        case length([UInt8])      // strings, sub-messages, packed repeated
+        case fixed64(UInt64)
+        case fixed32(UInt32)
+    }
+
+    struct Field {
+        let number: Int
+        let value: Value
+    }
+
+    private let bytes: [UInt8]
+    private var pos: Int
+    private let end: Int
+
+    init(_ bytes: [UInt8]) {
+        self.bytes = bytes
+        self.pos = 0
+        self.end = bytes.count
+    }
+
+    /// Returns the next field, or nil at end of message / on malformed input.
+    mutating func next() -> Field? {
+        guard pos < end, let tag = readVarint() else { return nil }
+        let number = Int(tag >> 3)
+        let wireType = Int(tag & 0x07)
+        guard number > 0 else { return nil }
+        switch wireType {
+        case 0:
+            guard let v = readVarint() else { return nil }
+            return Field(number: number, value: .varint(v))
+        case 1:
+            guard let v = readFixed(8) else { return nil }
+            return Field(number: number, value: .fixed64(v))
+        case 2:
+            guard let len = readVarint() else { return nil }
+            let length = Int(len)
+            guard length >= 0, pos + length <= end else { return nil }
+            let sub = Array(bytes[pos ..< pos + length])
+            pos += length
+            return Field(number: number, value: .length(sub))
+        case 5:
+            guard let v = readFixed(4) else { return nil }
+            return Field(number: number, value: .fixed32(UInt32(truncatingIfNeeded: v)))
+        default:
+            // Groups / unknown wire types: stop.
+            return nil
+        }
+    }
+
+    private mutating func readVarint() -> UInt64? {
+        var result: UInt64 = 0
+        var shift: UInt64 = 0
+        while pos < end {
+            let byte = bytes[pos]
+            pos += 1
+            result |= UInt64(byte & 0x7F) << shift
+            if byte & 0x80 == 0 { return result }
+            shift += 7
+            if shift >= 64 { return nil }
+        }
+        return nil
+    }
+
+    private mutating func readFixed(_ count: Int) -> UInt64? {
+        guard pos + count <= end else { return nil }
+        var value: UInt64 = 0
+        for k in 0 ..< count {
+            value |= UInt64(bytes[pos + k]) << (8 * k)
+        }
+        pos += count
+        return value
+    }
+}

--- a/Sources/PicoDocs/Converters/Pages/Snappy.swift
+++ b/Sources/PicoDocs/Converters/Pages/Snappy.swift
@@ -38,11 +38,11 @@ enum Snappy {
             let length = Int(data[i + 1]) | (Int(data[i + 2]) << 8) | (Int(data[i + 3]) << 16)
             i += 4
             guard i + length <= n else { throw SnappyError.malformed }
-            // Type 0x00 is a compressed block; iWork only ever emits this. Skip
-            // any other frame type's bytes defensively rather than failing.
-            if type == 0x00 {
-                output.append(contentsOf: try decompressBlock(Array(data[i ..< i + length])))
-            }
+            // iWork only ever emits compressed (0x00) chunks. Treat any other
+            // frame type as corruption rather than silently skipping it (which
+            // could drop body text); callers decide whether that's fatal.
+            guard type == 0x00 else { throw SnappyError.malformed }
+            output.append(contentsOf: try decompressBlock(Array(data[i ..< i + length])))
             i += length
         }
         return output
@@ -117,13 +117,19 @@ enum Snappy {
         while pos < input.count {
             let byte = input[pos]
             pos += 1
+            // Reject overflow before shifting: at the 10th byte (shift 63) only
+            // the low bit fits a 64-bit value; beyond that the varint is too long.
+            if shift == 63 {
+                if byte & 0x7E != 0 { throw SnappyError.malformed }
+            } else if shift >= 64 {
+                throw SnappyError.malformed
+            }
             result |= UInt64(byte & 0x7F) << shift
             if byte & 0x80 == 0 {
                 guard result <= UInt64(Int.max) else { throw SnappyError.malformed }
                 return Int(result)
             }
             shift += 7
-            if shift >= 64 { break }
         }
         throw SnappyError.malformed
     }

--- a/Sources/PicoDocs/Converters/Pages/Snappy.swift
+++ b/Sources/PicoDocs/Converters/Pages/Snappy.swift
@@ -37,7 +37,7 @@ enum Snappy {
             let type = data[i]
             let length = Int(data[i + 1]) | (Int(data[i + 2]) << 8) | (Int(data[i + 3]) << 16)
             i += 4
-            guard i + length <= n else { throw SnappyError.malformed }
+            guard length <= n - i else { throw SnappyError.malformed }
             // iWork only ever emits compressed (0x00) chunks. Treat any other
             // frame type as corruption rather than silently skipping it (which
             // could drop body text); callers decide whether that's fatal.
@@ -75,7 +75,7 @@ enum Snappy {
                     pos += extra
                 }
                 length += 1
-                guard pos + length <= n else { throw SnappyError.malformed }
+                guard length <= n - pos else { throw SnappyError.malformed }
                 output.append(contentsOf: input[pos ..< pos + length])
                 pos += length
             case 0x01:

--- a/Sources/PicoDocs/Converters/Pages/Snappy.swift
+++ b/Sources/PicoDocs/Converters/Pages/Snappy.swift
@@ -1,0 +1,138 @@
+//
+//  Snappy.swift
+//  PicoDocs
+//
+//  Minimal Snappy block decompressor plus the iWork `.iwa` chunk framing.
+//
+//  An iWork Archive (`.iwa`) stores its protobuf object stream as a sequence of
+//  Snappy-compressed chunks. The framing is Snappy's "framing format" but
+//  trimmed: each chunk is a 4-byte header — a `0x00` type byte (always a
+//  compressed chunk for iWork) followed by a 24-bit little-endian length — then
+//  that many bytes of a raw Snappy-compressed block. iWork omits the stream
+//  identifier and the per-chunk CRC-32C the spec otherwise requires.
+//
+//  Implemented in-module (no SwiftProtobuf, no external Snappy) to keep PicoDocs
+//  dependency-light. Format references: obriensp/iWorkFileFormat, the SheetJS IWA
+//  notes, and Cocoanetics/SwiftText (MIT).
+//
+
+import Foundation
+
+enum Snappy {
+
+    enum SnappyError: Error {
+        case malformed
+    }
+
+    /// Decompresses an iWork `.iwa` payload: concatenated `[0x00, len24-LE, block]`
+    /// frames, each `block` a raw Snappy-compressed block. Returns the assembled
+    /// protobuf object stream.
+    static func decompressIWA(_ data: [UInt8]) throws -> [UInt8] {
+        var output: [UInt8] = []
+        var i = 0
+        let n = data.count
+        while i < n {
+            // 4-byte frame header: type (1) + length (3, little-endian).
+            guard i + 4 <= n else { throw SnappyError.malformed }
+            let type = data[i]
+            let length = Int(data[i + 1]) | (Int(data[i + 2]) << 8) | (Int(data[i + 3]) << 16)
+            i += 4
+            guard i + length <= n else { throw SnappyError.malformed }
+            // Type 0x00 is a compressed block; iWork only ever emits this. Skip
+            // any other frame type's bytes defensively rather than failing.
+            if type == 0x00 {
+                output.append(contentsOf: try decompressBlock(Array(data[i ..< i + length])))
+            }
+            i += length
+        }
+        return output
+    }
+
+    /// Decompresses a single raw Snappy block (preamble varint = uncompressed
+    /// length, then a stream of literal and copy elements).
+    static func decompressBlock(_ input: [UInt8]) throws -> [UInt8] {
+        var pos = 0
+        let expectedLength = try readPreambleLength(input, &pos)
+        var output: [UInt8] = []
+        output.reserveCapacity(expectedLength)
+
+        let n = input.count
+        while pos < n {
+            let tag = input[pos]
+            pos += 1
+            switch tag & 0x03 {
+            case 0x00:
+                // Literal. Upper 6 bits encode (length - 1) directly, or — for the
+                // values 60...63 — the number of trailing little-endian length bytes.
+                var length = Int(tag >> 2)
+                if length >= 60 {
+                    let extra = length - 59
+                    guard pos + extra <= n else { throw SnappyError.malformed }
+                    length = Int(readLittleEndian(input, pos, extra))
+                    pos += extra
+                }
+                length += 1
+                guard pos + length <= n else { throw SnappyError.malformed }
+                output.append(contentsOf: input[pos ..< pos + length])
+                pos += length
+            case 0x01:
+                // Copy, 1-byte offset: length 4...11, 11-bit offset.
+                let length = 4 + Int((tag >> 2) & 0x07)
+                guard pos + 1 <= n else { throw SnappyError.malformed }
+                let offset = (Int(tag >> 5) << 8) | Int(input[pos])
+                pos += 1
+                try appendCopy(&output, offset: offset, length: length)
+            case 0x02:
+                // Copy, 2-byte offset.
+                let length = 1 + Int(tag >> 2)
+                guard pos + 2 <= n else { throw SnappyError.malformed }
+                let offset = Int(input[pos]) | (Int(input[pos + 1]) << 8)
+                pos += 2
+                try appendCopy(&output, offset: offset, length: length)
+            default:
+                // Copy, 4-byte offset.
+                let length = 1 + Int(tag >> 2)
+                guard pos + 4 <= n else { throw SnappyError.malformed }
+                let offset = Int(readLittleEndian(input, pos, 4))
+                pos += 4
+                try appendCopy(&output, offset: offset, length: length)
+            }
+        }
+        return output
+    }
+
+    /// Reads the block's leading varint (the uncompressed length).
+    private static func readPreambleLength(_ input: [UInt8], _ pos: inout Int) throws -> Int {
+        var result = 0
+        var shift = 0
+        while pos < input.count {
+            let byte = input[pos]
+            pos += 1
+            result |= Int(byte & 0x7F) << shift
+            if byte & 0x80 == 0 { return result }
+            shift += 7
+            if shift > 35 { break }
+        }
+        throw SnappyError.malformed
+    }
+
+    /// Reads `count` (1...4) little-endian bytes as an unsigned integer.
+    private static func readLittleEndian(_ input: [UInt8], _ start: Int, _ count: Int) -> UInt32 {
+        var value: UInt32 = 0
+        for k in 0 ..< count {
+            value |= UInt32(input[start + k]) << (8 * k)
+        }
+        return value
+    }
+
+    /// Appends a back-reference copy byte-by-byte, so overlapping runs (offset <
+    /// length) expand correctly — the Snappy way to encode repeats.
+    private static func appendCopy(_ output: inout [UInt8], offset: Int, length: Int) throws {
+        guard offset > 0, offset <= output.count else { throw SnappyError.malformed }
+        var src = output.count - offset
+        for _ in 0 ..< length {
+            output.append(output[src])
+            src += 1
+        }
+    }
+}

--- a/Sources/PicoDocs/Converters/Pages/Snappy.swift
+++ b/Sources/PicoDocs/Converters/Pages/Snappy.swift
@@ -54,7 +54,10 @@ enum Snappy {
         var pos = 0
         let expectedLength = try readPreambleLength(input, &pos)
         var output: [UInt8] = []
-        output.reserveCapacity(expectedLength)
+        // `expectedLength` is an attacker-controlled hint: cap the pre-allocation
+        // so a malformed block can't force a huge reserve (OOM). Real output stays
+        // bounded by the finite input regardless of the claimed length.
+        output.reserveCapacity(min(expectedLength, 16 * 1024 * 1024))
 
         let n = input.count
         while pos < n {
@@ -103,15 +106,20 @@ enum Snappy {
 
     /// Reads the block's leading varint (the uncompressed length).
     private static func readPreambleLength(_ input: [UInt8], _ pos: inout Int) throws -> Int {
-        var result = 0
-        var shift = 0
+        // Accumulate in UInt64 so the shift (up to 63) is safe on 32-bit `Int`
+        // platforms, then validate the result fits an `Int`.
+        var result: UInt64 = 0
+        var shift: UInt64 = 0
         while pos < input.count {
             let byte = input[pos]
             pos += 1
-            result |= Int(byte & 0x7F) << shift
-            if byte & 0x80 == 0 { return result }
+            result |= UInt64(byte & 0x7F) << shift
+            if byte & 0x80 == 0 {
+                guard result <= UInt64(Int.max) else { throw SnappyError.malformed }
+                return Int(result)
+            }
             shift += 7
-            if shift > 35 { break }
+            if shift >= 64 { break }
         }
         throw SnappyError.malformed
     }

--- a/Sources/PicoDocs/Converters/Pages/Snappy.swift
+++ b/Sources/PicoDocs/Converters/Pages/Snappy.swift
@@ -101,6 +101,10 @@ enum Snappy {
                 try appendCopy(&output, offset: offset, length: length)
             }
         }
+        // A well-formed Snappy block decodes to exactly its preamble length; a
+        // mismatch means the block was truncated/corrupt — reject it rather than
+        // emit partial text as a successful decode.
+        guard output.count == expectedLength else { throw SnappyError.malformed }
         return output
     }
 

--- a/Sources/PicoDocs/Converters/Pages/Snappy.swift
+++ b/Sources/PicoDocs/Converters/Pages/Snappy.swift
@@ -76,6 +76,7 @@ enum Snappy {
                 }
                 length += 1
                 guard length <= n - pos else { throw SnappyError.malformed }
+                guard output.count + length <= expectedLength else { throw SnappyError.malformed }
                 output.append(contentsOf: input[pos ..< pos + length])
                 pos += length
             case 0x01:
@@ -84,21 +85,21 @@ enum Snappy {
                 guard pos + 1 <= n else { throw SnappyError.malformed }
                 let offset = (Int(tag >> 5) << 8) | Int(input[pos])
                 pos += 1
-                try appendCopy(&output, offset: offset, length: length)
+                try appendCopy(&output, offset: offset, length: length, limit: expectedLength)
             case 0x02:
                 // Copy, 2-byte offset.
                 let length = 1 + Int(tag >> 2)
                 guard pos + 2 <= n else { throw SnappyError.malformed }
                 let offset = Int(input[pos]) | (Int(input[pos + 1]) << 8)
                 pos += 2
-                try appendCopy(&output, offset: offset, length: length)
+                try appendCopy(&output, offset: offset, length: length, limit: expectedLength)
             default:
                 // Copy, 4-byte offset.
                 let length = 1 + Int(tag >> 2)
                 guard pos + 4 <= n else { throw SnappyError.malformed }
                 let offset = Int(readLittleEndian(input, pos, 4))
                 pos += 4
-                try appendCopy(&output, offset: offset, length: length)
+                try appendCopy(&output, offset: offset, length: length, limit: expectedLength)
             }
         }
         // A well-formed Snappy block decodes to exactly its preamble length; a
@@ -145,8 +146,11 @@ enum Snappy {
 
     /// Appends a back-reference copy byte-by-byte, so overlapping runs (offset <
     /// length) expand correctly — the Snappy way to encode repeats.
-    private static func appendCopy(_ output: inout [UInt8], offset: Int, length: Int) throws {
+    private static func appendCopy(_ output: inout [UInt8], offset: Int, length: Int, limit: Int) throws {
         guard offset > 0, offset <= output.count else { throw SnappyError.malformed }
+        // A valid block never expands past its preamble length; reject corrupt
+        // tags that would balloon output before the final size check.
+        guard output.count + length <= limit else { throw SnappyError.malformed }
         var src = output.count - offset
         for _ in 0 ..< length {
             output.append(output[src])

--- a/Sources/PicoDocs/Detection/ContentTypeDetector.swift
+++ b/Sources/PicoDocs/Detection/ContentTypeDetector.swift
@@ -218,9 +218,16 @@ public enum ContentTypeDetector {
     /// Numbers/Keynote will get their own `DetectedFormat` cases when supported.
     static func iworkFormatFromHints(_ info: StreamInfo) -> DetectedFormat? {
         if let ut = info.utType, ut.conforms(to: .pages) { return .pages }
-        switch info.fileExtension?.lowercased() {
-        case "pages": return .pages
-        default: return nil
+        if info.fileExtension?.lowercased() == "pages" { return .pages }
+        // Extensionless web downloads: route by the Pages MIME type (current and
+        // legacy), since the URL may carry no `.pages` suffix.
+        let baseMIME = info.mimeType?.split(separator: ";").first
+            .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+        switch baseMIME {
+        case "application/vnd.apple.pages", "application/x-iwork-pages-sffpages":
+            return .pages
+        default:
+            return nil
         }
     }
 

--- a/Sources/PicoDocs/Detection/ContentTypeDetector.swift
+++ b/Sources/PicoDocs/Detection/ContentTypeDetector.swift
@@ -81,6 +81,9 @@ public enum ContentTypeDetector {
         // 3. Document formats identified by hint but lacking magic bytes (corrupt
         //    or mislabeled). Honor the hint so they reach the right converter (or
         //    report unsupported) instead of being mis-read as text.
+        if let iwork = iworkFormatFromHints(info) {
+            return (iwork, 0.4)
+        }
         if let docHint = documentFormatFromHints(info) {
             return (docHint, 0.4)
         }

--- a/Sources/PicoDocs/Detection/ContentTypeDetector.swift
+++ b/Sources/PicoDocs/Detection/ContentTypeDetector.swift
@@ -217,7 +217,7 @@ public enum ContentTypeDetector {
     /// Resolves iWork formats from hints. Only Pages has a converter today;
     /// Numbers/Keynote will get their own `DetectedFormat` cases when supported.
     static func iworkFormatFromHints(_ info: StreamInfo) -> DetectedFormat? {
-        if let ut = info.utType, ut.conforms(to: .pages) { return .pages }
+        if let ut = info.utType, ut.conforms(to: .pages) || ut.conforms(to: .pagesSingleFile) { return .pages }
         if info.fileExtension?.lowercased() == "pages" { return .pages }
         // Extensionless web downloads: route by the Pages MIME type (current and
         // legacy), since the URL may carry no `.pages` suffix.

--- a/Sources/PicoDocs/Detection/ContentTypeDetector.swift
+++ b/Sources/PicoDocs/Detection/ContentTypeDetector.swift
@@ -48,12 +48,20 @@ public enum ContentTypeDetector {
             || data.starts(with: Magic.zipEmpty)
             || data.starts(with: Magic.zipSpanned) {
             let zipFormat = classifyZip(data)
-            // If the archive couldn't be subtyped (generic .zip) but the caller's
-            // filename/MIME claims a specific OOXML/EPUB document — e.g. a
-            // truncated `report.docx` that still begins with PK — honor that hint
-            // so it routes to the right converter rather than the generic zip path.
-            if zipFormat == .zip, let docHint = documentFormatFromHints(info) {
-                return (docHint, 0.5)
+            if zipFormat == .zip {
+                // iWork '13+ packages are ZIPs without OOXML/EPUB markers. Route to
+                // the Pages converter when the filename/UTType says Pages, raising
+                // confidence when the archive's IWA layout confirms it.
+                if let iwork = iworkFormatFromHints(info) {
+                    return (iwork, isIWorkArchive(data) ? 0.95 : 0.5)
+                }
+                // If the archive couldn't be subtyped (generic .zip) but the
+                // caller's filename/MIME claims a specific OOXML/EPUB document —
+                // e.g. a truncated `report.docx` that still begins with PK — honor
+                // that hint so it routes to the right converter.
+                if let docHint = documentFormatFromHints(info) {
+                    return (docHint, 0.5)
+                }
             }
             return (zipFormat, 0.9)
         }
@@ -201,6 +209,29 @@ public enum ContentTypeDetector {
         case "epub": return .epub
         default: return nil
         }
+    }
+
+    /// Resolves iWork formats from hints. Only Pages has a converter today;
+    /// Numbers/Keynote will get their own `DetectedFormat` cases when supported.
+    static func iworkFormatFromHints(_ info: StreamInfo) -> DetectedFormat? {
+        if let ut = info.utType, ut.conforms(to: .pages) { return .pages }
+        switch info.fileExtension?.lowercased() {
+        case "pages": return .pages
+        default: return nil
+        }
+    }
+
+    /// Best-effort check that a ZIP is an iWork '13+ package: it carries IWA
+    /// component streams (`*.iwa`, possibly inside a nested `Index.zip`) or the
+    /// iWork `Metadata/DocumentIdentifier`. Scans the central directory when
+    /// locatable (authoritative), else a bounded whole-archive scan — mirroring
+    /// `classifyZipEntries`.
+    static func isIWorkArchive(_ data: Data) -> Bool {
+        let markers = [".iwa", "Index.zip", "Metadata/DocumentIdentifier"]
+        if let cd = zipCentralDirectory(data) {
+            return markers.contains { cd.range(of: Data($0.utf8)) != nil }
+        }
+        return markers.contains { boundedContains(data, Data($0.utf8)) }
     }
 
     /// Resolves text-family formats from extension / UTType. The extension switch

--- a/Sources/PicoDocs/Extensions/UTType.swift
+++ b/Sources/PicoDocs/Extensions/UTType.swift
@@ -24,6 +24,8 @@ public extension UTType {
     static let pptx = UTType(importedAs: "org.openxmlformats.presentationml.presentation", conformingTo: .zip)
     static let xhtml = UTType(importedAs: "public.xhtml", conformingTo: .xml)
     static let webloc = UTType(importedAs: "com.apple.web-internet-location")
+    // Apple Pages (iWork '13+) is a ZIP package of IWA streams, not XML.
+    static let pages = UTType(importedAs: "com.apple.iwork.pages.pages", conformingTo: .zip)
 
     /// Array of all supported documents
     static let supportedDocumentTypes: [UTType] = {
@@ -31,7 +33,7 @@ public extension UTType {
             .folder, .directory,
             .webloc,
             .doc, .docx, .xlsx,
-            .epub,
+            .epub, .pages,
             .pdf, .rtf, .rtfd, .text, .flatRTFD, .plainText, .utf8PlainText, .xml,
             .spreadsheet, .commaSeparatedText,
             .internetLocation, .internetShortcut, .url, .urlBookmarkData, .html, .xhtml,

--- a/Sources/PicoDocs/Extensions/UTType.swift
+++ b/Sources/PicoDocs/Extensions/UTType.swift
@@ -24,8 +24,10 @@ public extension UTType {
     static let pptx = UTType(importedAs: "org.openxmlformats.presentationml.presentation", conformingTo: .zip)
     static let xhtml = UTType(importedAs: "public.xhtml", conformingTo: .xml)
     static let webloc = UTType(importedAs: "com.apple.web-internet-location")
-    // Apple Pages (iWork '13+) is a ZIP package of IWA streams, not XML.
+    // Apple Pages (iWork '13+) is a ZIP package of IWA streams, not XML. Apple
+    // platforms may report either the package form or the flat single-file form.
     static let pages = UTType(importedAs: "com.apple.iwork.pages.pages", conformingTo: .zip)
+    static let pagesSingleFile = UTType(importedAs: "com.apple.iwork.pages.sffpages", conformingTo: .zip)
 
     /// Array of all supported documents
     static let supportedDocumentTypes: [UTType] = {
@@ -33,7 +35,7 @@ public extension UTType {
             .folder, .directory,
             .webloc,
             .doc, .docx, .xlsx,
-            .epub, .pages,
+            .epub, .pages, .pagesSingleFile,
             .pdf, .rtf, .rtfd, .text, .flatRTFD, .plainText, .utf8PlainText, .xml,
             .spreadsheet, .commaSeparatedText,
             .internetLocation, .internetShortcut, .url, .urlBookmarkData, .html, .xhtml,

--- a/Sources/PicoDocs/Models/StreamInfo.swift
+++ b/Sources/PicoDocs/Models/StreamInfo.swift
@@ -17,6 +17,7 @@ public enum DetectedFormat: String, Sendable, Equatable, Codable, CaseIterable {
     case xlsx
     case pptx
     case epub
+    case pages
     case html
     case rtf
     case plainText

--- a/Tests/PicoDocsTests/PagesConverterTests.swift
+++ b/Tests/PicoDocsTests/PagesConverterTests.swift
@@ -1,0 +1,240 @@
+//
+//  PagesConverterTests.swift
+//  PicoDocsTests
+//
+//  Exercises the in-module iWork Pages reader end to end without needing a real
+//  Pages.app file: the Snappy and protobuf-wire building blocks are tested with
+//  hand-built byte vectors, and a synthetic `.pages` package (a hand-rolled,
+//  stored ZIP containing one Snappy-framed `Index/Document.iwa`) drives the full
+//  PagesConverter path.
+//
+
+import Foundation
+import Testing
+@testable import PicoDocs
+
+struct PagesConverterTests {
+
+    // MARK: - Snappy
+
+    @Test("Snappy decompresses a literal-only block")
+    func snappyLiteral() throws {
+        // preamble length 5, literal tag ((5-1) << 2 = 0x10), then "Hello".
+        let block: [UInt8] = [0x05, 0x10] + Array("Hello".utf8)
+        #expect(try Snappy.decompressBlock(block) == Array("Hello".utf8))
+    }
+
+    @Test("Snappy expands an overlapping copy back-reference")
+    func snappyOverlappingCopy() throws {
+        // "ababab": literal "ab", then a 1-byte-offset copy (offset 2, length 4).
+        let block: [UInt8] = [
+            0x06,                                   // preamble: uncompressed length 6
+            0x04, UInt8(ascii: "a"), UInt8(ascii: "b"),  // literal "ab"
+            0x01, 0x02,                              // copy: length 4, offset 2
+        ]
+        #expect(try Snappy.decompressBlock(block) == Array("ababab".utf8))
+    }
+
+    @Test("Snappy round-trips an iWork frame")
+    func snappyFrameRoundTrips() throws {
+        let payload = Array("The quick brown fox".utf8)
+        let framed = Self.snappyFrame(payload)
+        #expect(try Snappy.decompressIWA(framed) == payload)
+    }
+
+    // MARK: - IWA stream
+
+    @Test("IWAArchive joins text runs from a TSWP storage")
+    func iwaTextExtraction() {
+        let stream = Self.makeIWAStream(runs: ["Hello, ", "Pages!"])
+        #expect(IWAArchive.text(in: stream) == "Hello, Pages!")
+    }
+
+    @Test("IWAArchive ignores non-text object types")
+    func iwaIgnoresOtherTypes() {
+        // A type-2001 storage plus a decoy object of another type carrying a
+        // field-3 string that must NOT be extracted.
+        let stream = Self.makeIWAStream(runs: ["real"]) + Self.makeIWAStream(runs: ["noise"], type: 6000)
+        #expect(IWAArchive.text(in: stream) == "real")
+    }
+
+    // MARK: - End to end
+
+    @Test("PagesConverter extracts body text from a synthetic .pages package")
+    func pagesEndToEnd() async throws {
+        let pages = Self.makePagesFile(paragraphs: ["First paragraph.", "Second paragraph."])
+        let result = try await PicoDocsEngine.convert(data: pages, filename: "sample.pages")
+        let markdown = result.markdown()
+        #expect(markdown.contains("First paragraph."))
+        #expect(markdown.contains("Second paragraph."))
+    }
+
+    @Test("Detector routes a .pages package to the Pages format")
+    func detectionRoutesToPages() {
+        let pages = Self.makePagesFile(paragraphs: ["Hi"])
+        let info = PicoDocsEngine.makeStreamInfo(filename: "note.pages", mimeType: nil, url: nil, charset: nil)
+        let resolved = ContentTypeDetector.classify(pages, info: info)
+        #expect(resolved.detectedFormat == .pages)
+    }
+
+    @Test("PagesConverter reports unsupported for a non-iWork zip")
+    func nonIWorkZipUnsupported() async {
+        // A .pages-named zip with no IWA streams should fail cleanly, not crash.
+        let zip = Self.makeZip([(name: "random.txt", data: Array("hi".utf8))])
+        await #expect(throws: Error.self) {
+            _ = try await PagesConverter().convert(
+                zip, info: PicoDocsEngine.makeStreamInfo(
+                    filename: "x.pages", mimeType: nil, url: nil, charset: nil
+                )
+            )
+        }
+    }
+
+    // MARK: - Fixture builders
+
+    /// A decompressed IWA object stream with a single storage (default type 2001)
+    /// whose field-3 runs are `runs`.
+    static func makeIWAStream(runs: [String], type: UInt64 = 2001) -> [UInt8] {
+        var payload: [UInt8] = []
+        for run in runs {
+            payload += tag(field: 3, wire: 2)
+            let bytes = Array(run.utf8)
+            payload += varint(UInt64(bytes.count))
+            payload += bytes
+        }
+        // MessageInfo { type = 1; length = 3 }
+        var messageInfo: [UInt8] = []
+        messageInfo += tag(field: 1, wire: 0); messageInfo += varint(type)
+        messageInfo += tag(field: 3, wire: 0); messageInfo += varint(UInt64(payload.count))
+        // ArchiveInfo { identifier = 1; message_infos = 2 }
+        var archiveInfo: [UInt8] = []
+        archiveInfo += tag(field: 1, wire: 0); archiveInfo += varint(1)
+        archiveInfo += tag(field: 2, wire: 2); archiveInfo += varint(UInt64(messageInfo.count)); archiveInfo += messageInfo
+        // Object = varint(archiveInfo length) · archiveInfo · payload
+        var stream: [UInt8] = []
+        stream += varint(UInt64(archiveInfo.count))
+        stream += archiveInfo
+        stream += payload
+        return stream
+    }
+
+    /// Wraps a stream in a single Snappy literal block + one iWork frame header.
+    static func snappyFrame(_ stream: [UInt8]) -> [UInt8] {
+        var block = varint(UInt64(stream.count))   // preamble: uncompressed length
+        block += literalElement(stream)
+        var frame: [UInt8] = [0x00]                 // chunk type: compressed
+        let len = block.count
+        frame += [UInt8(len & 0xFF), UInt8((len >> 8) & 0xFF), UInt8((len >> 16) & 0xFF)]
+        frame += block
+        return frame
+    }
+
+    /// A minimal stored (uncompressed) `.pages` ZIP with one `Index/Document.iwa`.
+    static func makePagesFile(paragraphs: [String]) -> Data {
+        let text = paragraphs.joined(separator: "\n")
+        let iwa = snappyFrame(makeIWAStream(runs: [text]))
+        return makeZip([(name: "Index/Document.iwa", data: iwa)])
+    }
+
+    // MARK: protobuf wire encoders
+
+    static func tag(field: Int, wire: Int) -> [UInt8] { varint(UInt64(field << 3 | wire)) }
+
+    static func varint(_ value: UInt64) -> [UInt8] {
+        var v = value
+        var out: [UInt8] = []
+        repeat {
+            var byte = UInt8(v & 0x7F)
+            v >>= 7
+            if v != 0 { byte |= 0x80 }
+            out.append(byte)
+        } while v != 0
+        return out
+    }
+
+    /// A Snappy literal element for `bytes` (handles the 60+ extended-length form).
+    static func literalElement(_ bytes: [UInt8]) -> [UInt8] {
+        guard !bytes.isEmpty else { return [] }
+        let lenMinus1 = bytes.count - 1
+        var out: [UInt8] = []
+        if lenMinus1 < 60 {
+            out.append(UInt8(lenMinus1 << 2))
+        } else {
+            var v = lenMinus1
+            var lenBytes: [UInt8] = []
+            while v > 0 { lenBytes.append(UInt8(v & 0xFF)); v >>= 8 }
+            out.append(UInt8((59 + lenBytes.count) << 2))   // tag: (60 + (count-1)) << 2
+            out += lenBytes
+        }
+        out += bytes
+        return out
+    }
+
+    // MARK: minimal stored-ZIP writer
+
+    /// Builds a stored (no compression) ZIP from `files`. Deterministic and
+    /// version-independent, so fixtures don't depend on a ZIP-write API.
+    static func makeZip(_ files: [(name: String, data: [UInt8])]) -> Data {
+        var out = Data()
+        var central = Data()
+        var records: [(name: [UInt8], crc: UInt32, size: Int, offset: Int)] = []
+
+        func put16(_ d: inout Data, _ v: Int) { d.append(UInt8(v & 0xFF)); d.append(UInt8((v >> 8) & 0xFF)) }
+        func put32(_ d: inout Data, _ v: UInt32) {
+            d.append(UInt8(v & 0xFF)); d.append(UInt8((v >> 8) & 0xFF))
+            d.append(UInt8((v >> 16) & 0xFF)); d.append(UInt8((v >> 24) & 0xFF))
+        }
+
+        for file in files {
+            let name = Array(file.name.utf8)
+            let crc = crc32(file.data)
+            let offset = out.count
+            put32(&out, 0x04034b50)                  // local file header signature
+            put16(&out, 20); put16(&out, 0); put16(&out, 0)   // version, flags, method (stored)
+            put16(&out, 0); put16(&out, 0)            // mod time, date
+            put32(&out, crc)
+            put32(&out, UInt32(file.data.count)); put32(&out, UInt32(file.data.count))
+            put16(&out, name.count); put16(&out, 0)   // name length, extra length
+            out.append(contentsOf: name)
+            out.append(contentsOf: file.data)
+            records.append((name, crc, file.data.count, offset))
+        }
+
+        let centralStart = out.count
+        for r in records {
+            put32(&central, 0x02014b50)               // central directory header signature
+            put16(&central, 20); put16(&central, 20)  // version made by, needed
+            put16(&central, 0); put16(&central, 0)    // flags, method
+            put16(&central, 0); put16(&central, 0)    // mod time, date
+            put32(&central, r.crc)
+            put32(&central, UInt32(r.size)); put32(&central, UInt32(r.size))
+            put16(&central, r.name.count)             // name length
+            put16(&central, 0); put16(&central, 0)    // extra, comment length
+            put16(&central, 0); put16(&central, 0)    // disk number start, internal attrs
+            put32(&central, 0)                        // external attrs
+            put32(&central, UInt32(r.offset))         // local header offset
+            central.append(contentsOf: r.name)
+        }
+        out.append(central)
+
+        var eocd = Data()
+        put32(&eocd, 0x06054b50)                      // end of central directory signature
+        put16(&eocd, 0); put16(&eocd, 0)              // disk numbers
+        put16(&eocd, records.count); put16(&eocd, records.count)
+        put32(&eocd, UInt32(central.count)); put32(&eocd, UInt32(centralStart))
+        put16(&eocd, 0)                               // comment length
+        out.append(eocd)
+        return out
+    }
+
+    static func crc32(_ bytes: [UInt8]) -> UInt32 {
+        var crc: UInt32 = 0xFFFFFFFF
+        for byte in bytes {
+            crc ^= UInt32(byte)
+            for _ in 0 ..< 8 {
+                crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB88320 : (crc >> 1)
+            }
+        }
+        return crc ^ 0xFFFFFFFF
+    }
+}

--- a/Tests/PicoDocsTests/PagesConverterTests.swift
+++ b/Tests/PicoDocsTests/PagesConverterTests.swift
@@ -77,6 +77,16 @@ struct PagesConverterTests {
         #expect(resolved.detectedFormat == .pages)
     }
 
+    @Test("Detector routes a Pages MIME type without a .pages extension")
+    func detectionRoutesByMIME() {
+        let pages = Self.makePagesFile(paragraphs: ["Hi"])
+        let info = PicoDocsEngine.makeStreamInfo(
+            filename: "download", mimeType: "application/vnd.apple.pages", url: nil, charset: nil
+        )
+        let resolved = ContentTypeDetector.classify(pages, info: info)
+        #expect(resolved.detectedFormat == .pages)
+    }
+
     @Test("PagesConverter reports unsupported for a non-iWork zip")
     func nonIWorkZipUnsupported() async {
         // A .pages-named zip with no IWA streams should fail cleanly, not crash.


### PR DESCRIPTION
## What & why

Next roadmap slice (OCR ✅ → Unicode sanitization ✅ → **Pages** → Keynote → Numbers). Adds first-class support for modern **Apple Pages** documents (iWork '13+), decoding the iWork Archive (**IWA**) format **entirely in-module** — no Pages.app, no Apple frameworks, and **no protobuf/snappy dependency**, keeping PicoDocs dependency-light.

## How it works

A `.pages` file is a ZIP whose content lives in `Index/*.iwa` (or a nested `Index.zip`). Each `.iwa` is a Snappy-framed stream of protobuf objects whose `TSWP.StorageArchive` messages carry the body text.

- **`Snappy.swift`** — iWork's `.iwa` chunk framing (`0x00` + 24-bit LE length) + a Snappy block decompressor (literals + overlapping copies).
- **`ProtobufReader.swift`** — a minimal protobuf **wire-format** reader (varint / 64-bit / length-delimited / 32-bit). Enough to walk IWA messages by field number *without* the proprietary `.proto` schemas.
- **`IWAArchive.swift`** — iterates the decompressed object stream (`varint·ArchiveInfo·payload`), reading `ArchiveInfo {identifier=1, message_infos=2}` and `MessageInfo {type=1, length=3}`, then extracts text from `TSWP.StorageArchive` objects (**type 2001**, `repeated string text = 3`).
- **`PagesConverter.swift`** — opens the `.pages` ZIP (loose `Index/*.iwa` or nested `Index.zip`), prefers `Document.iwa`, and emits a normalized body section.

Detection routes `.pages` (by extension/UTType, confirmed by the archive's IWA layout) to the new `DetectedFormat.pages`; the converter is registered at specific priority and `.pages` is added to the supported UTTypes.

## Scope (v1)

Plain **body text** extraction. Rich structure — headings, styling, tables, footnotes, inline images — and the legacy iWork '09 XML format are planned follow-ups. Inputs the reader can't yet handle raise a clear error rather than emitting nothing.

## Testing

No external fixtures and no Pages.app required:
- Snappy literal + overlapping-copy vectors and an `.iwa` frame round-trip.
- IWA text extraction, including ignoring non-text object types.
- **End-to-end**: a synthetic `.pages` built from a hand-rolled stored ZIP + synthetic Snappy/protobuf, run through `PicoDocsEngine.convert`, plus detection routing and a clean failure for a non-iWork zip.

> [!NOTE]
> The tests prove the decoder is internally consistent and the IWA constants are wired correctly, but it has **not yet been validated against a real Pages.app file**. Adding one real `.pages` to `Tests/PicoDocsTests/Resources/` is a good follow-up to confirm against the actual format.

## Attribution

Format references: [obriensp/iWorkFileFormat](https://github.com/obriensp/iWorkFileFormat), the [SheetJS IWA notes](https://github.com/SheetJS/notes/blob/main/iwa/README.md), and [Cocoanetics/SwiftText](https://github.com/Cocoanetics/SwiftText) (MIT) — the in-module decode approach is informed by SwiftText's `SwiftTextPages` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mxnj6jvuLX9VS9JsJJbjmf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mxnj6jvuLX9VS9JsJJbjmf)_