### PR TITLE
Pages: filter to body storages (kind==0) + control-char cleanup, validated against a real .pages

### DIFF
--- a/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
@@ -129,21 +129,19 @@ enum IWAArchive {
     /// (protobuf default 0). Header/footer/footnote storages (non-zero kind) return
     /// nil so callers skip them.
     private static func bodyText(in payload: [UInt8]) -> String? {
-        var kind: UInt64 = 0
         var runs: [String] = []
         var reader = ProtobufReader(payload)
         while let field = reader.next() {
             switch (field.number, field.value) {
-            case (1, .varint(let k)):                   // StorageArchive.kind
-                kind = k
+            case (1, .varint(let kind)):                // StorageArchive.kind
+                guard kind == 0 else { return nil }     // non-body (header/footer/…) → skip
             case (3, .length(let bytes)):               // repeated string text
                 if let run = String(bytes: bytes, encoding: .utf8) { runs.append(run) }
             default:
                 continue
             }
         }
-        guard kind == 0 else { return nil }             // 0 = body
-        return runs.joined()
+        return runs.joined()                            // kind 0 or absent (default 0) = body
     }
 }
 

--- a/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
@@ -21,16 +21,16 @@ import Foundation
 
 enum IWAArchive {
 
-    /// The TSWP text storage message type (`TSWP.StorageArchive`). Its field 3 is
-    /// `repeated string text` — the document's paragraph text runs. Shared across
+    /// The TSWP text storage message type (`TSWP.StorageArchive`): field 1 is the
+    /// storage `kind` (0 = body; non-zero = header/footer/footnote/…) and field 3
+    /// is `repeated string text`, the paragraph text runs. Shared across
     /// Pages/Numbers/Keynote.
     ///
-    /// Only the well-established id 2001 is matched. Other ids occasionally cited
-    /// for text storage (e.g. 2005) are deliberately not included until confirmed
-    /// against a real Pages file / the type registry — a wrong id would surface
-    /// non-text payloads as garbage. Revisit with the real-file fixture follow-up.
+    /// Confirmed against a real Pages file: 2001 is the text storage and the body
+    /// is `kind == 0`. The alternate id 2005 sometimes cited for text storage did
+    /// not appear there, so it's intentionally not matched (a wrong id would
+    /// surface non-text payloads as garbage).
     static let textStorageType: UInt64 = 2001
-    static let textRunsField = 3
 
     struct Object {
         let identifier: UInt64
@@ -65,20 +65,16 @@ enum IWAArchive {
         return objects
     }
 
-    /// Concatenated plain text from all TSWP text storages in the stream, in
-    /// object order. Each storage's `repeated string text` runs are joined; a
-    /// blank line separates distinct storages (body, header/footer, footnotes…).
-    ///
-    /// NOTE: this includes *all* type-2001 storages rather than filtering to body
-    /// storages via `StorageArchive.kind` (field 1). The KindType enum values
-    /// aren't verified against a real Pages file, and filtering on a wrong value
-    /// would drop real body text; confirming `kind` (and the alternate id 2005)
-    /// against a real fixture is part of the real-file-validation follow-up.
+    /// Concatenated plain *body* text from the stream's TSWP text storages, in
+    /// object order. Only body storages (`kind == 0`) are included — header,
+    /// footer, footnote, and text-box storages (non-zero `kind`) are skipped so
+    /// their text isn't passed off as the document body. Each storage's `repeated
+    /// string text` runs are joined; a blank line separates distinct body storages.
     static func text(in stream: [UInt8]) -> String {
         var storages: [String] = []
         for object in objects(in: stream) where object.type == textStorageType {
-            let joined = textRuns(in: object.payload).joined()
-            if !joined.isEmpty { storages.append(joined) }
+            guard let body = bodyText(in: object.payload), !body.isEmpty else { continue }
+            storages.append(body)
         }
         return storages.joined(separator: "\n\n")
     }
@@ -128,18 +124,26 @@ enum IWAArchive {
         return (type, length)
     }
 
-    /// TSWP.StorageArchive: field 3 is `repeated string text`. Returns the runs in
-    /// order (concatenation reconstructs the storage's full text).
-    private static func textRuns(in payload: [UInt8]) -> [String] {
+    /// TSWP.StorageArchive: the concatenated `repeated string text` (field 3) runs,
+    /// but only when this is a *body* storage — `kind` (field 1) is 0, or absent
+    /// (protobuf default 0). Header/footer/footnote storages (non-zero kind) return
+    /// nil so callers skip them.
+    private static func bodyText(in payload: [UInt8]) -> String? {
+        var kind: UInt64 = 0
         var runs: [String] = []
         var reader = ProtobufReader(payload)
         while let field = reader.next() {
-            if field.number == textRunsField, case .length(let bytes) = field.value,
-               let run = String(bytes: bytes, encoding: .utf8) {
-                runs.append(run)
+            switch (field.number, field.value) {
+            case (1, .varint(let k)):                   // StorageArchive.kind
+                kind = k
+            case (3, .length(let bytes)):               // repeated string text
+                if let run = String(bytes: bytes, encoding: .utf8) { runs.append(run) }
+            default:
+                continue
             }
         }
-        return runs
+        guard kind == 0 else { return nil }             // 0 = body
+        return runs.joined()
     }
 }
 

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -136,6 +136,11 @@ public struct PagesConverter: DocumentConverter {
         for separator in ["\r\n", "\r", "\u{2028}", "\u{2029}", "\u{000B}", "\u{000C}"] {
             unified = unified.replacingOccurrences(of: separator, with: "\n")
         }
+        // Drop C0/C1 control characters (e.g. Pages' U+0004 section-break sentinel)
+        // that aren't real text; tab/newline are kept and handled by the line loop.
+        var scalars = unified.unicodeScalars
+        scalars.removeAll { $0 != "\n" && $0 != "\t" && $0.properties.generalCategory == .control }
+        unified = String(scalars)
         let inlineWhitespace = CharacterSet(charactersIn: " \t")
         var out: [String] = []
         var pendingBlank = false

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -139,7 +139,11 @@ public struct PagesConverter: DocumentConverter {
         // Drop C0/C1 control characters (e.g. Pages' U+0004 section-break sentinel)
         // that aren't real text; tab/newline are kept and handled by the line loop.
         var scalars = unified.unicodeScalars
-        scalars.removeAll { $0 != "\n" && $0 != "\t" && $0.properties.generalCategory == .control }
+        scalars.removeAll { scalar in
+            let value = scalar.value
+            guard value != 0x0A, value != 0x09 else { return false }  // keep newline, tab
+            return value <= 0x1F || (0x7F...0x9F).contains(value)      // C0 / C1 controls
+        }
         unified = String(scalars)
         let inlineWhitespace = CharacterSet(charactersIn: " \t")
         var out: [String] = []

--- a/Tests/PicoDocsTests/PagesConverterTests.swift
+++ b/Tests/PicoDocsTests/PagesConverterTests.swift
@@ -69,6 +69,31 @@ struct PagesConverterTests {
         #expect(markdown.contains("Second paragraph."))
     }
 
+    @Test("PagesConverter extracts body text from a real Pages fixture, excluding header/footer")
+    func realPagesFixture() async throws {
+        let data = try Fixture.data("sample", "pages")
+        let result = try await PicoDocsEngine.convert(data: data, filename: "sample.pages")
+        let markdown = result.markdown()
+
+        // Body storage (kind == 0) is extracted: heading, body paragraphs (incl.
+        // inline code, full Unicode coverage), and the end-of-document marker.
+        #expect(markdown.contains("Representative Import Fixture for Apple Pages"))
+        #expect(markdown.contains("let importer = PagesImporter()"))
+        #expect(markdown.contains("café, naïve"))
+        #expect(markdown.contains("🚀"))
+        #expect(markdown.contains("日本語"))
+        #expect(markdown.contains("END_OF_PAGES_IMPORT_FIXTURE"))
+
+        // Header/footer storages (kind == 1) are excluded from the body.
+        #expect(!markdown.contains("generated source DOCX"))
+        #expect(!markdown.contains("Fixture coverage: headings"))
+        #expect(!markdown.contains("End of fixture"))
+
+        // Control-character artifacts (e.g. the U+0004 section-break sentinel) are
+        // stripped from the output.
+        #expect(!markdown.unicodeScalars.contains("\u{0004}"))
+    }
+
     @Test("Detector routes a .pages package to the Pages format")
     func detectionRoutesToPages() {
         let pages = Self.makePagesFile(paragraphs: ["Hi"])


### PR DESCRIPTION
## What & why

The real-file follow-up to #28. Now that a real Pages.app document is committed at `Tests/PicoDocsTests/Resources/sample.pages`, I decoded its `Index/Document.iwa` and inspected the IWA objects to **confirm the constants that were deliberately deferred in #28** — then applied the resulting fixes.

## Confirmed against real data

- **`TSWP.StorageArchive` (type 2001), field 1 = `kind`:** `0` = body, non-zero = header/footer/footnote/etc. In the fixture the body is one `kind==0` storage (1371 chars); the four `kind==1` storages are header/footer text.
- **No `2005`:** the alternate storage id sometimes cited for text did **not** appear — 2001 is *the* text storage. The #28 deferral was correct; it stays unmatched.
- **Table text lives outside `Document.iwa`** (in `Index/Tables/*`, type 6002 + DataLists); the body carries `U+FFFC` object placeholders where the table/images are. Tables remain a separate follow-up.
- One artifact: Pages emits a stray **`U+0004`** section-break sentinel in the body text.

## Changes

- **`IWAArchive`** now extracts only **body** storages (`kind == 0`, or `kind` absent = protobuf default 0), so header/footer text is no longer appended to the document body. (Resolves the deferred `kind`-filter review item from #28.)
- **`PagesConverter.normalize`** drops C0/C1 control characters (e.g. `U+0004`) except tab/newline.
- **Real-fixture test:** asserts the body (heading, inline code `let importer = PagesImporter()`, full Unicode coverage `café, naïve`/`🚀`/`日本語`, and the `END_OF_PAGES_IMPORT_FIXTURE` end marker) is extracted, while the `kind==1` header/footer strings and the `U+0004` artifact are **not**.

I verified the expected output by decoding the fixture in Python (mirroring the `kind==0` filter + control-char strip) before writing the assertions; the synthetic tests still hold since their storages omit `kind` (→ default 0 = body).

## Still deferred (separate follow-ups)

Table cell extraction, inline images, rich structure (headings/styles), package-*directory* ingestion, and legacy iWork '09 — the fixture now makes these much easier to build and validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mxnj6jvuLX9VS9JsJJbjmf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mxnj6jvuLX9VS9JsJJbjmf)_