### PR TITLE
Keynote: deck-ordered slides via the document slide tree, validated on a real .key

### DIFF
--- a/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
@@ -99,25 +99,29 @@ enum IWAArchive {
     }
 
     /// Reads ArchiveInfo: identifier (field 1) + each MessageInfo (field 2) into
-    /// (identifier, type, length, references) entries.
+    /// (identifier, type, length, references) entries. Protobuf fields may be
+    /// serialized in any order, so the MessageInfo payloads are collected first
+    /// and stamped with the identifier only after the whole ArchiveInfo has been
+    /// scanned — never assuming field 1 precedes field 2 (an archive that emitted
+    /// `message_infos` first would otherwise get identifier 0, breaking the
+    /// object-graph lookups, e.g. Keynote's slide-tree ordering).
     private static func messageInfos(in archiveBytes: [UInt8]) -> [InfoEntry] {
         var identifier: UInt64 = 0
-        var entries: [InfoEntry] = []
+        var infos: [(type: UInt64, length: UInt64, references: [UInt64])] = []
         var reader = ProtobufReader(archiveBytes)
         while let field = reader.next() {
             switch (field.number, field.value) {
             case (1, .varint(let id)):
                 identifier = id
             case (2, .length(let messageInfoBytes)):
-                if let info = parseMessageInfo(messageInfoBytes) {
-                    entries.append(InfoEntry(identifier: identifier, type: info.type,
-                                             length: info.length, references: info.references))
-                }
+                if let info = parseMessageInfo(messageInfoBytes) { infos.append(info) }
             default:
                 continue
             }
         }
-        return entries
+        return infos.map {
+            InfoEntry(identifier: identifier, type: $0.type, length: $0.length, references: $0.references)
+        }
     }
 
     /// MessageInfo: type (field 1), payload length (field 3), and object_references

--- a/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
@@ -75,8 +75,14 @@ enum IWAArchive {
     /// their text isn't passed off as the document body. Each storage's `repeated
     /// string text` runs are joined; a blank line separates distinct body storages.
     static func text(in stream: [UInt8]) -> String {
+        text(from: objects(in: stream))
+    }
+
+    /// Body text from already-parsed objects — lets a caller that already has the
+    /// objects (e.g. Keynote, which also needs the slide id) avoid re-parsing.
+    static func text(from objects: [Object]) -> String {
         var storages: [String] = []
-        for object in objects(in: stream) where object.type == textStorageType {
+        for object in objects where object.type == textStorageType {
             guard let body = bodyText(in: object.payload), !body.isEmpty else { continue }
             storages.append(body)
         }

--- a/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
@@ -36,6 +36,9 @@ enum IWAArchive {
         let identifier: UInt64
         let type: UInt64
         let payload: [UInt8]
+        /// Cross-object references (`MessageInfo.object_references`), in order —
+        /// used to follow the document object graph (e.g. Keynote's slide tree).
+        let references: [UInt64]
     }
 
     /// Parses every object in a decompressed IWA stream. Best-effort: on a
@@ -59,7 +62,8 @@ enum IWAArchive {
             for info in infos {
                 guard info.length <= UInt64(Int.max),
                       let payload = cursor.take(Int(info.length)) else { return objects }
-                objects.append(Object(identifier: info.identifier, type: info.type, payload: payload))
+                objects.append(Object(identifier: info.identifier, type: info.type,
+                                      payload: payload, references: info.references))
             }
         }
         return objects
@@ -85,10 +89,11 @@ enum IWAArchive {
         let identifier: UInt64
         let type: UInt64
         let length: UInt64
+        let references: [UInt64]
     }
 
     /// Reads ArchiveInfo: identifier (field 1) + each MessageInfo (field 2) into
-    /// (identifier, type, length) entries.
+    /// (identifier, type, length, references) entries.
     private static func messageInfos(in archiveBytes: [UInt8]) -> [InfoEntry] {
         var identifier: UInt64 = 0
         var entries: [InfoEntry] = []
@@ -98,8 +103,9 @@ enum IWAArchive {
             case (1, .varint(let id)):
                 identifier = id
             case (2, .length(let messageInfoBytes)):
-                if let (type, length) = parseMessageInfo(messageInfoBytes) {
-                    entries.append(InfoEntry(identifier: identifier, type: type, length: length))
+                if let info = parseMessageInfo(messageInfoBytes) {
+                    entries.append(InfoEntry(identifier: identifier, type: info.type,
+                                             length: info.length, references: info.references))
                 }
             default:
                 continue
@@ -108,20 +114,32 @@ enum IWAArchive {
         return entries
     }
 
-    /// MessageInfo: type (field 1) + payload length (field 3).
-    private static func parseMessageInfo(_ bytes: [UInt8]) -> (type: UInt64, length: UInt64)? {
+    /// MessageInfo: type (field 1), payload length (field 3), and object_references
+    /// (field 5 — packed or repeated uint64).
+    private static func parseMessageInfo(_ bytes: [UInt8]) -> (type: UInt64, length: UInt64, references: [UInt64])? {
         var type: UInt64?
         var length: UInt64?
+        var references: [UInt64] = []
         var reader = ProtobufReader(bytes)
         while let field = reader.next() {
             switch (field.number, field.value) {
             case (1, .varint(let t)): type = t
             case (3, .varint(let l)): length = l
+            case (5, .varint(let r)): references.append(r)                       // unpacked
+            case (5, .length(let packed)): references.append(contentsOf: unpackVarints(packed))
             default: continue
             }
         }
         guard let type, let length else { return nil }
-        return (type, length)
+        return (type, length, references)
+    }
+
+    /// Unpacks a protobuf packed-repeated varint field.
+    private static func unpackVarints(_ bytes: [UInt8]) -> [UInt64] {
+        var values: [UInt64] = []
+        var cursor = StreamCursor(bytes)
+        while let value = cursor.readVarint() { values.append(value) }
+        return values
     }
 
     /// TSWP.StorageArchive: the concatenated `repeated string text` (field 3) runs,

--- a/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
@@ -55,9 +55,9 @@ public struct KeynoteConverter: DocumentConverter {
                 // corruption, not an empty slide.
                 throw PicoDocsError.fileCorrupted
             }
-            let slideID = IWAArchive.objects(in: stream)
-                .first { $0.type == Self.slideArchiveType }?.identifier ?? 0
-            slides.append((component.name, slideID, Self.normalize(IWAArchive.text(in: stream))))
+            let objects = IWAArchive.objects(in: stream)
+            let slideID = objects.first { $0.type == Self.slideArchiveType }?.identifier ?? 0
+            slides.append((component.name, slideID, Self.normalize(IWAArchive.text(from: objects))))
         }
 
         // Order by the document's slide tree (authoritative); fall back to

--- a/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
@@ -69,6 +69,11 @@ public struct KeynoteConverter: DocumentConverter {
             let rr = rank[rhs.id] ?? Int.max
             if lr != rr { return lr < rr }
             if lhs.id != rhs.id { return lhs.id < rhs.id }
+            // Final fallback (no slide tree, ids unresolved): numeric filename
+            // order, so Slide2 precedes Slide10 (lexicographic would not).
+            let lo = Self.slideOrder(lhs.name)
+            let ro = Self.slideOrder(rhs.name)
+            if lo != ro { return lo < ro }
             return lhs.name < rhs.name
         }
 
@@ -116,7 +121,17 @@ public struct KeynoteConverter: DocumentConverter {
 
     static func isMaster(_ path: String) -> Bool {
         let base = path.split(separator: "/").last.map(String.init) ?? path
-        return base.hasPrefix("MasterSlide")
+        return base.hasPrefix("MasterSlide") || base.hasPrefix("TemplateSlide")
+    }
+
+    /// The trailing number in a `Slide<N>.iwa` filename (`Slide12.iwa` → 12), used
+    /// only as the final ordering fallback when the slide tree and slide ids can't
+    /// be resolved. Numeric so `Slide2` precedes `Slide10`; unnumbered names
+    /// (e.g. `Slide.iwa`) sort last.
+    static func slideOrder(_ path: String) -> Int {
+        let base = path.split(separator: "/").last.map(String.init) ?? path
+        let digits = base.drop { !$0.isNumber }.prefix { $0.isNumber }
+        return Int(digits) ?? Int.max
     }
 
     /// KN.SlideArchive message type — the slide object inside each `Slide*.iwa`,

--- a/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
@@ -6,16 +6,16 @@
 //  reusing the in-module iWork Archive (IWA) decoder built for Pages — Snappy +
 //  protobuf-wire + `IWAArchive` (no Keynote.app, no Apple frameworks, no
 //  protobuf/snappy dependency). A `.key` is the same ZIP/IWA container; slides
-//  live in `Index/Slide<N>.iwa` (loose, or inside a nested `Index.zip`), with
-//  `MasterSlide-*.iwa` masters and `Document.iwa` presentation metadata.
+//  live in `Index/Slide*.iwa` (loose, or inside a nested `Index.zip`), with
+//  `MasterSlide-*.iwa` / `TemplateSlide-*.iwa` masters and `Document.iwa`
+//  presentation metadata (incl. the slide tree).
 //
-//  Scope (v1): each slide's body text (the `kind == 0` TSWP storages, same
-//  extraction as Pages) becomes one section, in slide-number order. Master/theme
-//  template text and presenter notes are excluded; speaker notes, per-slide
-//  titles vs body, ordering via the document object graph, tables, and inline
-//  images are follow-ups — best validated against a real `.key` fixture (the
-//  Pages real-file pass confirmed body = `kind 0`; slide-text kinds should be
-//  re-confirmed the same way).
+//  Scope: each slide's body text (the `kind == 0` TSWP storages, same extraction
+//  as Pages) becomes one section, in deck order resolved from `Document.iwa`'s
+//  slide tree. Master/template slides are excluded, and presenter notes (`kind`
+//  4) are excluded by the `kind == 0` filter — both confirmed against a real
+//  `.key` (kinds: 0=body, 1=header/footer, 4=note, 5=cell). Per-slide
+//  title-vs-body structure, tables, and inline images remain follow-ups.
 //
 //  NOTE: `readEntry` / `normalize` mirror PagesConverter; a shared iWork helper
 //  is a planned cleanup once both converters have settled.
@@ -41,31 +41,45 @@ public struct KeynoteConverter: DocumentConverter {
             throw PicoDocsError.documentTypeNotSupported
         }
 
-        // One section per slide (Index/Slide<N>.iwa), in slide-number order,
-        // excluding MasterSlide* template text.
-        let slides = components
-            .filter { Self.isSlide($0.name) }
-            .sorted { Self.slideOrder($0.name) < Self.slideOrder($1.name) }
-
-        var sections: [DocumentSection] = []
-        for (index, slide) in slides.enumerated() {
+        // Decompress each slide once; capture its KN.SlideArchive id (to resolve
+        // deck order from the document's slide tree) and its body text (kind == 0;
+        // presenter notes are kind 4 and so already excluded).
+        var slides: [(name: String, id: UInt64, text: String)] = []
+        for component in components where Self.isSlide(component.name) {
             try Task.checkCancellation()
-            // A slide's stream is primary content: a decompression failure is
-            // corruption, not an empty slide — fail rather than silently drop it.
             let stream: [UInt8]
             do {
-                stream = try Snappy.decompressIWA(slide.bytes)
+                stream = try Snappy.decompressIWA(component.bytes)
             } catch {
+                // A slide's stream is primary content: a decompression failure is
+                // corruption, not an empty slide.
                 throw PicoDocsError.fileCorrupted
             }
-            let text = Self.normalize(IWAArchive.text(in: stream))
-            guard !text.isEmpty else { continue }
-            // slideNumber reflects the slide's position in deck order (by Slide<N>
-            // filename), not the count of emitted sections, so skipping an empty
-            // slide doesn't renumber the slides after it.
+            let slideID = IWAArchive.objects(in: stream)
+                .first { $0.type == Self.slideArchiveType }?.identifier ?? 0
+            slides.append((component.name, slideID, Self.normalize(IWAArchive.text(in: stream))))
+        }
+
+        // Order by the document's slide tree (authoritative); fall back to
+        // slide-archive id, then filename, when it can't be resolved.
+        let deck = Self.deckOrder(components: components, slideIDs: Set(slides.map(\.id)))
+        let rank = Dictionary(deck.enumerated().map { ($1, $0) }, uniquingKeysWith: { first, _ in first })
+        let ordered = slides.sorted { lhs, rhs in
+            let lr = rank[lhs.id] ?? Int.max
+            let rr = rank[rhs.id] ?? Int.max
+            if lr != rr { return lr < rr }
+            if lhs.id != rhs.id { return lhs.id < rhs.id }
+            return lhs.name < rhs.name
+        }
+
+        var sections: [DocumentSection] = []
+        for (index, slide) in ordered.enumerated() {
+            // slideNumber is the deck position, so skipping an empty slide leaves a
+            // gap rather than renumbering the slides after it.
+            guard !slide.text.isEmpty else { continue }
             sections.append(DocumentSection(
                 kind: .slide,
-                markdown: text,
+                markdown: slide.text,
                 sourcePath: slide.name,
                 slideNumber: index + 1
             ))
@@ -105,12 +119,38 @@ public struct KeynoteConverter: DocumentConverter {
         return base.hasPrefix("MasterSlide")
     }
 
-    /// The trailing slide number from the filename (`Slide12.iwa` → 12), for
-    /// ordering. Falls back to `Int.max` so unnumbered names sort last/stably.
-    static func slideOrder(_ path: String) -> Int {
-        let base = path.split(separator: "/").last.map(String.init) ?? path
-        let digits = base.drop { !$0.isNumber }.prefix { $0.isNumber }
-        return Int(digits) ?? Int.max
+    /// KN.SlideArchive message type — the slide object inside each `Slide*.iwa`,
+    /// whose identifier the document's slide tree references (confirmed against a
+    /// real `.key`).
+    static let slideArchiveType: UInt64 = 5
+
+    /// Resolves deck order from `Document.iwa`'s slide tree: each tree node
+    /// references one slide, and the tree references its nodes in order. Returns
+    /// slide ids in deck order, or empty if it can't be resolved (caller then
+    /// falls back to slide-id / filename order). Structural — it identifies the
+    /// tree and nodes via the reference graph rather than hard-coding their
+    /// message types; only the slide-archive type above is fixed.
+    private static func deckOrder(components: [Component], slideIDs: Set<UInt64>) -> [UInt64] {
+        guard !slideIDs.isEmpty,
+              let doc = components.first(where: { $0.name.hasSuffix("Document.iwa") }),
+              let stream = try? Snappy.decompressIWA(doc.bytes) else { return [] }
+        let objects = IWAArchive.objects(in: stream)
+        // A slide-tree node references exactly one slide; map node id -> slide id.
+        var nodeToSlide: [UInt64: UInt64] = [:]
+        for object in objects {
+            if let slideID = object.references.first(where: { slideIDs.contains($0) }) {
+                nodeToSlide[object.identifier] = slideID
+            }
+        }
+        guard !nodeToSlide.isEmpty else { return [] }
+        // The slide tree is the object referencing the most of those nodes; its
+        // node references, in order, give the deck order.
+        var orderedNodes: [UInt64] = []
+        for object in objects {
+            let nodes = object.references.filter { nodeToSlide[$0] != nil }
+            if nodes.count > orderedNodes.count { orderedNodes = nodes }
+        }
+        return orderedNodes.compactMap { nodeToSlide[$0] }
     }
 
     // MARK: - IWA gathering

--- a/Tests/PicoDocsTests/KeynoteConverterTests.swift
+++ b/Tests/PicoDocsTests/KeynoteConverterTests.swift
@@ -114,4 +114,32 @@ struct KeynoteConverterTests {
             _ = try await KeynoteConverter().convert(key, info: info)
         }
     }
+
+    @Test("KeynoteConverter extracts deck-ordered slide text from a real .key, excluding presenter notes")
+    func realKeynoteFixture() async throws {
+        let data = try Fixture.data("sample", "key")
+        let result = try await PicoDocsEngine.convert(data: data, filename: "sample.key")
+
+        let slides = result.sections.filter { $0.kind == .slide }
+        #expect(slides.count == 3)
+        #expect(slides.map(\.slideNumber) == [1, 2, 3])
+
+        // Deck order comes from Document.iwa's slide tree, NOT the filenames:
+        // Slide.iwa ("The problem") is slide 2, not last. (Filename order would
+        // put it last and swap slides 2/3.)
+        #expect(slides[0].markdown.contains("The Spoon"))
+        #expect(slides[0].markdown.contains("Ronald Mannak"))
+        #expect(slides[1].markdown.contains("The problem"))
+        #expect(slides[1].markdown.contains("Every mug has a spoon-shaped absence"))
+        #expect(slides[2].markdown.contains("The data"))
+
+        // Presenter notes are kind 4 → excluded by the kind==0 filter; they must
+        // not leak into slide text.
+        let markdown = result.markdown()
+        #expect(!markdown.contains("Good morning. Thank you all"))
+        #expect(!markdown.contains("barista pea"))
+
+        // Object-replacement image placeholders are stripped.
+        #expect(!markdown.unicodeScalars.contains("\u{FFFC}"))
+    }
 }

--- a/Tests/PicoDocsTests/PagesConverterTests.swift
+++ b/Tests/PicoDocsTests/PagesConverterTests.swift
@@ -58,6 +58,27 @@ struct PagesConverterTests {
         #expect(IWAArchive.text(in: stream) == "real")
     }
 
+    @Test("IWAArchive captures the identifier regardless of ArchiveInfo field order")
+    func iwaIdentifierOrderIndependent() {
+        // Protobuf fields may be serialized in any order: an ArchiveInfo that
+        // emits message_infos (field 2) BEFORE identifier (field 1) must still
+        // attach the right id (it would be 0 if we trusted field order).
+        let payload = Array("body".utf8)
+        var storage: [UInt8] = []                         // TSWP.StorageArchive { text }
+        storage += Self.tag(field: 3, wire: 2) + Self.varint(UInt64(payload.count)) + payload
+        var messageInfo: [UInt8] = []                     // MessageInfo { type=2001; length }
+        messageInfo += Self.tag(field: 1, wire: 0) + Self.varint(2001)
+        messageInfo += Self.tag(field: 3, wire: 0) + Self.varint(UInt64(storage.count))
+        var archiveInfo: [UInt8] = []                     // field 2 before field 1
+        archiveInfo += Self.tag(field: 2, wire: 2) + Self.varint(UInt64(messageInfo.count)) + messageInfo
+        archiveInfo += Self.tag(field: 1, wire: 0) + Self.varint(4242)
+        var stream: [UInt8] = []
+        stream += Self.varint(UInt64(archiveInfo.count)) + archiveInfo + storage
+
+        #expect(IWAArchive.objects(in: stream).first?.identifier == 4242)
+        #expect(IWAArchive.text(in: stream) == "body")
+    }
+
     // MARK: - End to end
 
     @Test("PagesConverter extracts body text from a synthetic .pages package")


### PR DESCRIPTION
## What & why

The Keynote **real-file validation** follow-up to #30 (the `.key` analogue of #29 for Pages). Using the `sample.key` fixture you added, I decoded the IWA object graph to verify the import and fix what the real file revealed.

## Verified against `sample.key`
- ✅ **Slide text** extracts (titles + body).
- ✅ **Presenter notes are excluded** — they're **`kind = 4`**, so the existing `kind == 0` filter already drops them; the long speaker notes do **not** leak. (kinds observed: `0`=body, `1`=header/footer, `4`=note, `5`=cell.)
- ✅ `￼` image placeholders stripped (the #30 fix).
- ❌ **Slide ordering was wrong** — fixed here.

## The fix: deck order from the slide tree

Slides are `Index/Slide.iwa` / `Slide-<id>.iwa`; the filename-number sort mis-ordered them (`Slide.iwa` → "The problem" sorted *last*). The authoritative order lives in `Document.iwa`'s **slide tree**: a tree object's `object_references` list the slide-tree **nodes** in order, and each node references one slide (`KN.SlideArchive`, type 5).

- **`IWAArchive`** now captures `MessageInfo.object_references` (field 5, packed/repeated) on each `Object` — additive; Pages is unaffected.
- **`KeynoteConverter.deckOrder`** resolves the order structurally (it discovers the tree/nodes via the reference graph rather than hard-coding their message types; only the slide-archive type is fixed), with a graceful fallback to slide-archive id, then filename, if the tree can't be read.

For `sample.key` this yields the correct **The Spoon (title) → The problem → The data** instead of the filename order which swaps slides 2/3.

## Test

Real-fixture test asserting: 3 slides in **deck order** (`Slide.iwa` is slide 2, not last), titles+body present, presenter-note text (`"Good morning…"`, `"barista pea"`) **absent**, and no `U+FFFC`. Synthetic tests still pass (no `Document.iwa`/type-5 → fall back to name order).

I validated the exact ordering + extraction in Python against the fixture before porting to Swift.

## Still deferred
Per-slide *title vs body* structure, tables, inline images; and the shared follow-ups (FileFetcher package-directory for `.key`/`.pages`, `IWASupport` refactor, MIME provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mxnj6jvuLX9VS9JsJJbjmf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mxnj6jvuLX9VS9JsJJbjmf)_