### PR TITLE
Document known limitation with iWork table positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Refer to the [example app](PicoDocsExample/) for detailed guidance.
 
 Create a PR to include your app here.
 
+## Known Limitations
+
+- **iWork table positioning**: Tables in Pages and Keynote documents are extracted and appended after the document body rather than placed inline at their original position in the text. Restoring inline table placement is planned for a future release.
+
 ## License
 
 PicoDocs is released under the MIT license.


### PR DESCRIPTION
## Summary
This PR adds documentation of a known limitation regarding table positioning in iWork documents (Pages and Keynote).

## Changes
- Added "Known Limitations" section to README.md
- Documented that tables in Pages and Keynote documents are currently extracted and appended after the document body rather than placed inline at their original position
- Noted that restoring inline table placement is planned for a future release

## Details
This change improves transparency about current limitations in the PicoDocs library by setting user expectations around iWork table handling. Users will now be aware that while tables are extracted and included in the output, their positioning may differ from the source document.

https://claude.ai/code/session_01Mxnj6jvuLX9VS9JsJJbjmf