### PR TITLE
Add table reconstruction and improve Keynote slide ordering

### DIFF
--- a/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
@@ -99,25 +99,29 @@ enum IWAArchive {
     }
 
     /// Reads ArchiveInfo: identifier (field 1) + each MessageInfo (field 2) into
-    /// (identifier, type, length, references) entries.
+    /// (identifier, type, length, references) entries. Protobuf fields may be
+    /// serialized in any order, so the MessageInfo payloads are collected first
+    /// and stamped with the identifier only after the whole ArchiveInfo has been
+    /// scanned — never assuming field 1 precedes field 2 (an archive that emitted
+    /// `message_infos` first would otherwise get identifier 0, breaking the
+    /// object-graph lookups, e.g. Keynote's slide-tree ordering).
     private static func messageInfos(in archiveBytes: [UInt8]) -> [InfoEntry] {
         var identifier: UInt64 = 0
-        var entries: [InfoEntry] = []
+        var infos: [(type: UInt64, length: UInt64, references: [UInt64])] = []
         var reader = ProtobufReader(archiveBytes)
         while let field = reader.next() {
             switch (field.number, field.value) {
             case (1, .varint(let id)):
                 identifier = id
             case (2, .length(let messageInfoBytes)):
-                if let info = parseMessageInfo(messageInfoBytes) {
-                    entries.append(InfoEntry(identifier: identifier, type: info.type,
-                                             length: info.length, references: info.references))
-                }
+                if let info = parseMessageInfo(messageInfoBytes) { infos.append(info) }
             default:
                 continue
             }
         }
-        return entries
+        return infos.map {
+            InfoEntry(identifier: identifier, type: $0.type, length: $0.length, references: $0.references)
+        }
     }
 
     /// MessageInfo: type (field 1), payload length (field 3), and object_references

--- a/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
@@ -75,8 +75,14 @@ enum IWAArchive {
     /// their text isn't passed off as the document body. Each storage's `repeated
     /// string text` runs are joined; a blank line separates distinct body storages.
     static func text(in stream: [UInt8]) -> String {
+        text(from: objects(in: stream))
+    }
+
+    /// Body text from already-parsed objects — lets a caller that already has the
+    /// objects (e.g. Keynote, which also needs the slide id) avoid re-parsing.
+    static func text(from objects: [Object]) -> String {
         var storages: [String] = []
-        for object in objects(in: stream) where object.type == textStorageType {
+        for object in objects where object.type == textStorageType {
             guard let body = bodyText(in: object.payload), !body.isEmpty else { continue }
             storages.append(body)
         }

--- a/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWAArchive.swift
@@ -36,6 +36,9 @@ enum IWAArchive {
         let identifier: UInt64
         let type: UInt64
         let payload: [UInt8]
+        /// Cross-object references (`MessageInfo.object_references`), in order —
+        /// used to follow the document object graph (e.g. Keynote's slide tree).
+        let references: [UInt64]
     }
 
     /// Parses every object in a decompressed IWA stream. Best-effort: on a
@@ -59,7 +62,8 @@ enum IWAArchive {
             for info in infos {
                 guard info.length <= UInt64(Int.max),
                       let payload = cursor.take(Int(info.length)) else { return objects }
-                objects.append(Object(identifier: info.identifier, type: info.type, payload: payload))
+                objects.append(Object(identifier: info.identifier, type: info.type,
+                                      payload: payload, references: info.references))
             }
         }
         return objects
@@ -85,10 +89,11 @@ enum IWAArchive {
         let identifier: UInt64
         let type: UInt64
         let length: UInt64
+        let references: [UInt64]
     }
 
     /// Reads ArchiveInfo: identifier (field 1) + each MessageInfo (field 2) into
-    /// (identifier, type, length) entries.
+    /// (identifier, type, length, references) entries.
     private static func messageInfos(in archiveBytes: [UInt8]) -> [InfoEntry] {
         var identifier: UInt64 = 0
         var entries: [InfoEntry] = []
@@ -98,8 +103,9 @@ enum IWAArchive {
             case (1, .varint(let id)):
                 identifier = id
             case (2, .length(let messageInfoBytes)):
-                if let (type, length) = parseMessageInfo(messageInfoBytes) {
-                    entries.append(InfoEntry(identifier: identifier, type: type, length: length))
+                if let info = parseMessageInfo(messageInfoBytes) {
+                    entries.append(InfoEntry(identifier: identifier, type: info.type,
+                                             length: info.length, references: info.references))
                 }
             default:
                 continue
@@ -108,20 +114,32 @@ enum IWAArchive {
         return entries
     }
 
-    /// MessageInfo: type (field 1) + payload length (field 3).
-    private static func parseMessageInfo(_ bytes: [UInt8]) -> (type: UInt64, length: UInt64)? {
+    /// MessageInfo: type (field 1), payload length (field 3), and object_references
+    /// (field 5 — packed or repeated uint64).
+    private static func parseMessageInfo(_ bytes: [UInt8]) -> (type: UInt64, length: UInt64, references: [UInt64])? {
         var type: UInt64?
         var length: UInt64?
+        var references: [UInt64] = []
         var reader = ProtobufReader(bytes)
         while let field = reader.next() {
             switch (field.number, field.value) {
             case (1, .varint(let t)): type = t
             case (3, .varint(let l)): length = l
+            case (5, .varint(let r)): references.append(r)                       // unpacked
+            case (5, .length(let packed)): references.append(contentsOf: unpackVarints(packed))
             default: continue
             }
         }
         guard let type, let length else { return nil }
-        return (type, length)
+        return (type, length, references)
+    }
+
+    /// Unpacks a protobuf packed-repeated varint field.
+    private static func unpackVarints(_ bytes: [UInt8]) -> [UInt64] {
+        var values: [UInt64] = []
+        var cursor = StreamCursor(bytes)
+        while let value = cursor.readVarint() { values.append(value) }
+        return values
     }
 
     /// TSWP.StorageArchive: the concatenated `repeated string text` (field 3) runs,

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -233,7 +233,7 @@ enum IWATable {
         let rows: [[String]] = grid.map { row in
             row.map { key in
                 guard let key, let text = strings[key] else { return "" }
-                return escape(text)
+                return cleanCell(text)
             }
         }
         let columnCount = rows.map(\.count).max() ?? 0
@@ -250,18 +250,33 @@ enum IWATable {
         return lines.joined(separator: "\n")
     }
 
-    /// Escapes characters that would break a Markdown table cell: backslash and
-    /// pipe are escaped, and every line/paragraph separator (CR-LF, CR, LF, and
-    /// the Unicode separators iWork uses) is folded to a single space so a
-    /// multi-line cell stays on one row. CR-LF is handled before the bare CR/LF
-    /// so it collapses to one space, not two. Same separator set as
-    /// `PagesConverter.normalize`.
-    private static func escape(_ text: String) -> String {
-        var escaped = text.replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "|", with: "\\|")
+    /// Cleans a cell's raw storage text for a Markdown table cell, mirroring
+    /// `PagesConverter.normalize`:
+    ///  • folds every line/paragraph separator (CR-LF, CR, LF, and the Unicode
+    ///    separators iWork uses) to a single space so a multi-line cell stays on
+    ///    one row — CR-LF first, so it collapses to one space, not two;
+    ///  • drops the U+FFFC object-replacement sentinel (image / embedded-object
+    ///    placeholders) and C0/C1 control characters that aren't real text, so a
+    ///    placeholder-only cell becomes empty (and an all-placeholder table is
+    ///    skipped) rather than rendering as visible garbage;
+    ///  • escapes backslash and pipe so the text can't break the table; and
+    ///  • trims surrounding whitespace.
+    private static func cleanCell(_ text: String) -> String {
+        var folded = text
         for separator in ["\r\n", "\r", "\n", "\u{2028}", "\u{2029}", "\u{000B}", "\u{000C}"] {
-            escaped = escaped.replacingOccurrences(of: separator, with: " ")
+            folded = folded.replacingOccurrences(of: separator, with: " ")
         }
-        return escaped
+        var scalars = folded.unicodeScalars
+        scalars.removeAll { scalar in
+            let value = scalar.value
+            guard value != 0x09 else { return false }        // keep tab
+            return value <= 0x1F                              // C0 controls
+                || (0x7F...0x9F).contains(value)             // DEL + C1 controls
+                || value == 0xFFFC                           // object-replacement placeholder
+        }
+        let escaped = String(scalars)
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "|", with: "\\|")
+        return escaped.trimmingCharacters(in: .whitespaces)
     }
 }

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -1,0 +1,257 @@
+//
+//  IWATable.swift
+//  PicoDocs
+//
+//  Reconstructs Apple iWork (Pages/Numbers/Keynote) tables from decompressed IWA
+//  object streams into GitHub-flavored Markdown grid tables.
+//
+//  A table is assembled from three object kinds, joined through the document
+//  object graph (`MessageInfo.object_references`):
+//
+//    • TST.TableModelArchive (type 6001 / 6316) — the table itself; its
+//      references point at exactly one Tile and the DataLists backing its
+//      columns (one per aspect: strings, formats, styles, …).
+//    • TST.Tile (type 6002) — the cell grid: `repeated TileRowInfo` (field 5),
+//      each row carrying a packed cell buffer (field 6) and a uint16 offset
+//      array (field 7). A string cell record begins with the bytes `05 09` and
+//      stores its string key as a little-endian uint32 at byte offset 12.
+//    • TST.DataList (type 6005) with `list_type == 8` (field 1) — the string
+//      store: `repeated entry` (field 3) mapping a key (field 1) to a
+//      RichTextPayload reference (field 9 → type 6218 → type 2001
+//      TSWP.StorageArchive, whose `repeated string text` is the cell text).
+//
+//  Confirmed against a real `.pages` fixture (two text tables, 5×4 and 4×6,
+//  including empty cells and Unicode/URL content).
+//
+//  Scope (v1): text cells only — numeric/date/formula cells render as empty
+//  cells. Tables are emitted as standalone sections appended after the body
+//  rather than positioned inline at their attachment point (see README).
+//
+
+import Foundation
+
+enum IWATable {
+
+    private static let tileType: UInt64 = 6002
+    private static let dataListType: UInt64 = 6005
+    private static let stringListType: UInt64 = 8       // DataList.list_type for strings
+    private static let richTextPayloadType: UInt64 = 6218
+    private static let storageType: UInt64 = 2001
+
+    /// Reconstructs every text table found across the given decompressed IWA
+    /// streams, rendered as Markdown, ordered by tile identifier (a stable proxy
+    /// for document order). Best-effort: undecodable or empty tables are skipped,
+    /// so a document with no tables simply yields `[]`.
+    static func markdownTables(from streams: [[UInt8]]) -> [String] {
+        // A table model lives in CalculationEngine.iwa but references tiles and
+        // datalists in Tables/*.iwa, so the whole document is indexed by id.
+        var objects: [UInt64: IWAArchive.Object] = [:]
+        for stream in streams {
+            for object in IWAArchive.objects(in: stream) {
+                objects[object.identifier] = object
+            }
+        }
+        guard !objects.isEmpty else { return [] }
+
+        let tileIDs = Set(objects.values.filter { $0.type == tileType }.map(\.identifier))
+        guard !tileIDs.isEmpty else { return [] }
+
+        // Resolve every non-empty string DataList to key -> text.
+        var stringLists: [UInt64: [UInt32: String]] = [:]
+        for object in objects.values where object.type == dataListType {
+            if let map = stringList(object, objects: objects), !map.isEmpty {
+                stringLists[object.identifier] = map
+            }
+        }
+        guard !stringLists.isEmpty else { return [] }
+
+        // A table model references exactly one tile and the datalist holding its
+        // strings. Collect (tile, strings) pairs, then render once per tile in a
+        // stable order (Dictionary iteration order is unspecified).
+        var pairs: [(tile: UInt64, strings: UInt64)] = []
+        for object in objects.values {
+            guard let tile = object.references.first(where: { tileIDs.contains($0) }),
+                  let strings = object.references.first(where: { stringLists[$0] != nil }) else { continue }
+            pairs.append((tile, strings))
+        }
+        pairs.sort { $0.tile < $1.tile }
+
+        var tables: [String] = []
+        var seenTiles = Set<UInt64>()
+        for pair in pairs {
+            guard seenTiles.insert(pair.tile).inserted,
+                  let tile = objects[pair.tile], let strings = stringLists[pair.strings] else { continue }
+            if let markdown = render(grid: cellKeyGrid(tile), strings: strings) {
+                tables.append(markdown)
+            }
+        }
+        return tables
+    }
+
+    // MARK: - DataList (string store)
+
+    /// For a `list_type == 8` DataList, resolves entry key -> text by following
+    /// each entry's RichTextPayload reference (6218) to its TSWP.StorageArchive
+    /// (2001). Returns nil for non-string lists. Field order independent.
+    private static func stringList(_ object: IWAArchive.Object,
+                                   objects: [UInt64: IWAArchive.Object]) -> [UInt32: String]? {
+        var listType: UInt64?
+        var entries: [(key: UInt32, payload: UInt64)] = []
+        var reader = ProtobufReader(object.payload)
+        while let field = reader.next() {
+            switch (field.number, field.value) {
+            case (1, .varint(let type)):
+                listType = type
+            case (3, .length(let entryBytes)):
+                if let entry = dataListEntry(entryBytes) { entries.append(entry) }
+            default:
+                continue
+            }
+        }
+        guard let listType, listType == stringListType else { return nil }
+
+        var map: [UInt32: String] = [:]
+        for entry in entries {
+            guard let richText = objects[entry.payload], richText.type == richTextPayloadType,
+                  let storageID = referencedID(in: richText.payload),
+                  let storage = objects[storageID], storage.type == storageType else { continue }
+            map[entry.key] = storageText(storage.payload)
+        }
+        return map
+    }
+
+    /// One DataList entry: key (field 1) + RichTextPayload id (field 9 → field 1).
+    private static func dataListEntry(_ bytes: [UInt8]) -> (key: UInt32, payload: UInt64)? {
+        var key: UInt32?
+        var payload: UInt64?
+        var reader = ProtobufReader(bytes)
+        while let field = reader.next() {
+            switch (field.number, field.value) {
+            case (1, .varint(let k)):
+                key = UInt32(truncatingIfNeeded: k)
+            case (9, .length(let sub)):
+                payload = referencedID(in: sub)
+            default:
+                continue
+            }
+        }
+        guard let key, let payload else { return nil }
+        return (key, payload)
+    }
+
+    /// Reads a referenced object id out of field 1 — either a bare varint id or a
+    /// TSP.Reference sub-message whose field 1 is the id. Used for both the
+    /// DataList entry → RichTextPayload and RichTextPayload → Storage hops.
+    private static func referencedID(in bytes: [UInt8]) -> UInt64? {
+        var reader = ProtobufReader(bytes)
+        while let field = reader.next() {
+            guard field.number == 1 else { continue }
+            switch field.value {
+            case .varint(let id):
+                return id
+            case .length(let sub):
+                if let id = referencedID(in: sub) { return id }
+            default:
+                continue
+            }
+        }
+        return nil
+    }
+
+    /// TSWP.StorageArchive text: the concatenated `repeated string text` (field 3).
+    private static func storageText(_ payload: [UInt8]) -> String {
+        var runs: [String] = []
+        var reader = ProtobufReader(payload)
+        while let field = reader.next() {
+            if field.number == 3, case .length(let bytes) = field.value,
+               let run = String(bytes: bytes, encoding: .utf8) {
+                runs.append(run)
+            }
+        }
+        return runs.joined()
+    }
+
+    // MARK: - Tile (cell grid)
+
+    /// Decodes a Tile into a grid of per-cell string keys (nil = empty or
+    /// non-text cell). Trailing empty columns are trimmed per row.
+    private static func cellKeyGrid(_ tile: IWAArchive.Object) -> [[UInt32?]] {
+        var rows: [[UInt32?]] = []
+        var reader = ProtobufReader(tile.payload)
+        while let field = reader.next() {
+            if field.number == 5, case .length(let rowBytes) = field.value {
+                rows.append(cellKeys(inRow: rowBytes))
+            }
+        }
+        return rows
+    }
+
+    /// One TileRowInfo: uint16 offsets (field 7) into the cell buffer (field 6);
+    /// 0xFFFF marks an absent cell.
+    private static func cellKeys(inRow rowBytes: [UInt8]) -> [UInt32?] {
+        var buffer: [UInt8] = []
+        var offsets: [UInt8] = []
+        var reader = ProtobufReader(rowBytes)
+        while let field = reader.next() {
+            switch (field.number, field.value) {
+            case (6, .length(let bytes)): buffer = bytes
+            case (7, .length(let bytes)): offsets = bytes
+            default: continue
+            }
+        }
+        var keys: [UInt32?] = []
+        var i = 0
+        while i + 1 < offsets.count {
+            let offset = Int(offsets[i]) | (Int(offsets[i + 1]) << 8)
+            i += 2
+            keys.append(offset == 0xFFFF ? nil : stringKey(inCell: buffer, at: offset))
+        }
+        while let last = keys.last, last == nil { keys.removeLast() }   // trim trailing empties
+        return keys
+    }
+
+    /// The string key stored in a cell record, or nil if it isn't a string cell
+    /// (`05 09` marker) or would read out of bounds. The key is a little-endian
+    /// uint32 at byte offset 12.
+    private static func stringKey(inCell buffer: [UInt8], at offset: Int) -> UInt32? {
+        guard offset >= 0, offset + 16 <= buffer.count,
+              buffer[offset] == 0x05, buffer[offset + 1] == 0x09 else { return nil }
+        let k = offset + 12
+        return UInt32(buffer[k]) | (UInt32(buffer[k + 1]) << 8)
+            | (UInt32(buffer[k + 2]) << 16) | (UInt32(buffer[k + 3]) << 24)
+    }
+
+    // MARK: - Markdown rendering
+
+    /// Renders a key grid + string map as a GitHub-flavored Markdown table (first
+    /// row is the header). Returns nil if there are no columns or no resolvable
+    /// text, so empty/placeholder tables are skipped.
+    private static func render(grid: [[UInt32?]], strings: [UInt32: String]) -> String? {
+        let rows: [[String]] = grid.map { row in
+            row.map { key in
+                guard let key, let text = strings[key] else { return "" }
+                return escape(text)
+            }
+        }
+        let columnCount = rows.map(\.count).max() ?? 0
+        guard columnCount > 0,
+              rows.contains(where: { $0.contains { !$0.isEmpty } }) else { return nil }
+
+        func line(_ row: [String]) -> String {
+            let padded = row + Array(repeating: "", count: max(0, columnCount - row.count))
+            return "| " + padded.joined(separator: " | ") + " |"
+        }
+        var lines = [line(rows[0])]
+        lines.append("| " + Array(repeating: "---", count: columnCount).joined(separator: " | ") + " |")
+        for row in rows.dropFirst() { lines.append(line(row)) }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Escapes characters that would break a Markdown table cell.
+    private static func escape(_ text: String) -> String {
+        text.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "|", with: "\\|")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+    }
+}

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -37,6 +37,7 @@ enum IWATable {
     private static let stringListType: UInt64 = 8       // DataList.list_type for strings
     private static let richTextPayloadType: UInt64 = 6218
     private static let storageType: UInt64 = 2001
+    private static let tableModelTypes: Set<UInt64> = [6001, 6316]   // TST.TableModelArchive
 
     /// Reconstructs every text table found across the given decompressed IWA
     /// streams, rendered as Markdown, ordered by tile identifier (a stable proxy
@@ -66,10 +67,12 @@ enum IWATable {
         guard !stringLists.isEmpty else { return [] }
 
         // A table model references exactly one tile and the datalist holding its
-        // strings. Collect (tile, strings) pairs, then render once per tile in a
-        // stable order (Dictionary iteration order is unspecified).
+        // strings. Restrict to the known table-model types so an unrelated object
+        // that happens to reference both can't be mistaken for a table. Collect
+        // (tile, strings) pairs, then render once per tile in a stable order
+        // (Dictionary iteration order is unspecified).
         var pairs: [(tile: UInt64, strings: UInt64)] = []
-        for object in objects.values {
+        for object in objects.values where tableModelTypes.contains(object.type) {
             guard let tile = object.references.first(where: { tileIDs.contains($0) }),
                   let strings = object.references.first(where: { stringLists[$0] != nil }) else { continue }
             pairs.append((tile, strings))
@@ -247,11 +250,18 @@ enum IWATable {
         return lines.joined(separator: "\n")
     }
 
-    /// Escapes characters that would break a Markdown table cell.
+    /// Escapes characters that would break a Markdown table cell: backslash and
+    /// pipe are escaped, and every line/paragraph separator (CR-LF, CR, LF, and
+    /// the Unicode separators iWork uses) is folded to a single space so a
+    /// multi-line cell stays on one row. CR-LF is handled before the bare CR/LF
+    /// so it collapses to one space, not two. Same separator set as
+    /// `PagesConverter.normalize`.
     private static func escape(_ text: String) -> String {
-        text.replacingOccurrences(of: "\\", with: "\\\\")
+        var escaped = text.replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "|", with: "\\|")
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "\r", with: " ")
+        for separator in ["\r\n", "\r", "\n", "\u{2028}", "\u{2029}", "\u{000B}", "\u{000C}"] {
+            escaped = escaped.replacingOccurrences(of: separator, with: " ")
+        }
+        return escaped
     }
 }

--- a/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
@@ -55,9 +55,9 @@ public struct KeynoteConverter: DocumentConverter {
                 // corruption, not an empty slide.
                 throw PicoDocsError.fileCorrupted
             }
-            let slideID = IWAArchive.objects(in: stream)
-                .first { $0.type == Self.slideArchiveType }?.identifier ?? 0
-            slides.append((component.name, slideID, Self.normalize(IWAArchive.text(in: stream))))
+            let objects = IWAArchive.objects(in: stream)
+            let slideID = objects.first { $0.type == Self.slideArchiveType }?.identifier ?? 0
+            slides.append((component.name, slideID, Self.normalize(IWAArchive.text(from: objects))))
         }
 
         // Order by the document's slide tree (authoritative); fall back to

--- a/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
@@ -69,6 +69,11 @@ public struct KeynoteConverter: DocumentConverter {
             let rr = rank[rhs.id] ?? Int.max
             if lr != rr { return lr < rr }
             if lhs.id != rhs.id { return lhs.id < rhs.id }
+            // Final fallback (no slide tree, ids unresolved): numeric filename
+            // order, so Slide2 precedes Slide10 (lexicographic would not).
+            let lo = Self.slideOrder(lhs.name)
+            let ro = Self.slideOrder(rhs.name)
+            if lo != ro { return lo < ro }
             return lhs.name < rhs.name
         }
 
@@ -116,7 +121,17 @@ public struct KeynoteConverter: DocumentConverter {
 
     static func isMaster(_ path: String) -> Bool {
         let base = path.split(separator: "/").last.map(String.init) ?? path
-        return base.hasPrefix("MasterSlide")
+        return base.hasPrefix("MasterSlide") || base.hasPrefix("TemplateSlide")
+    }
+
+    /// The trailing number in a `Slide<N>.iwa` filename (`Slide12.iwa` → 12), used
+    /// only as the final ordering fallback when the slide tree and slide ids can't
+    /// be resolved. Numeric so `Slide2` precedes `Slide10`; unnumbered names
+    /// (e.g. `Slide.iwa`) sort last.
+    static func slideOrder(_ path: String) -> Int {
+        let base = path.split(separator: "/").last.map(String.init) ?? path
+        let digits = base.drop { !$0.isNumber }.prefix { $0.isNumber }
+        return Int(digits) ?? Int.max
     }
 
     /// KN.SlideArchive message type — the slide object inside each `Slide*.iwa`,

--- a/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
@@ -6,16 +6,16 @@
 //  reusing the in-module iWork Archive (IWA) decoder built for Pages — Snappy +
 //  protobuf-wire + `IWAArchive` (no Keynote.app, no Apple frameworks, no
 //  protobuf/snappy dependency). A `.key` is the same ZIP/IWA container; slides
-//  live in `Index/Slide<N>.iwa` (loose, or inside a nested `Index.zip`), with
-//  `MasterSlide-*.iwa` masters and `Document.iwa` presentation metadata.
+//  live in `Index/Slide*.iwa` (loose, or inside a nested `Index.zip`), with
+//  `MasterSlide-*.iwa` / `TemplateSlide-*.iwa` masters and `Document.iwa`
+//  presentation metadata (incl. the slide tree).
 //
-//  Scope (v1): each slide's body text (the `kind == 0` TSWP storages, same
-//  extraction as Pages) becomes one section, in slide-number order. Master/theme
-//  template text and presenter notes are excluded; speaker notes, per-slide
-//  titles vs body, ordering via the document object graph, tables, and inline
-//  images are follow-ups — best validated against a real `.key` fixture (the
-//  Pages real-file pass confirmed body = `kind 0`; slide-text kinds should be
-//  re-confirmed the same way).
+//  Scope: each slide's body text (the `kind == 0` TSWP storages, same extraction
+//  as Pages) becomes one section, in deck order resolved from `Document.iwa`'s
+//  slide tree. Master/template slides are excluded, and presenter notes (`kind`
+//  4) are excluded by the `kind == 0` filter — both confirmed against a real
+//  `.key` (kinds: 0=body, 1=header/footer, 4=note, 5=cell). Per-slide
+//  title-vs-body structure, tables, and inline images remain follow-ups.
 //
 //  NOTE: `readEntry` / `normalize` mirror PagesConverter; a shared iWork helper
 //  is a planned cleanup once both converters have settled.
@@ -41,31 +41,45 @@ public struct KeynoteConverter: DocumentConverter {
             throw PicoDocsError.documentTypeNotSupported
         }
 
-        // One section per slide (Index/Slide<N>.iwa), in slide-number order,
-        // excluding MasterSlide* template text.
-        let slides = components
-            .filter { Self.isSlide($0.name) }
-            .sorted { Self.slideOrder($0.name) < Self.slideOrder($1.name) }
-
-        var sections: [DocumentSection] = []
-        for (index, slide) in slides.enumerated() {
+        // Decompress each slide once; capture its KN.SlideArchive id (to resolve
+        // deck order from the document's slide tree) and its body text (kind == 0;
+        // presenter notes are kind 4 and so already excluded).
+        var slides: [(name: String, id: UInt64, text: String)] = []
+        for component in components where Self.isSlide(component.name) {
             try Task.checkCancellation()
-            // A slide's stream is primary content: a decompression failure is
-            // corruption, not an empty slide — fail rather than silently drop it.
             let stream: [UInt8]
             do {
-                stream = try Snappy.decompressIWA(slide.bytes)
+                stream = try Snappy.decompressIWA(component.bytes)
             } catch {
+                // A slide's stream is primary content: a decompression failure is
+                // corruption, not an empty slide.
                 throw PicoDocsError.fileCorrupted
             }
-            let text = Self.normalize(IWAArchive.text(in: stream))
-            guard !text.isEmpty else { continue }
-            // slideNumber reflects the slide's position in deck order (by Slide<N>
-            // filename), not the count of emitted sections, so skipping an empty
-            // slide doesn't renumber the slides after it.
+            let slideID = IWAArchive.objects(in: stream)
+                .first { $0.type == Self.slideArchiveType }?.identifier ?? 0
+            slides.append((component.name, slideID, Self.normalize(IWAArchive.text(in: stream))))
+        }
+
+        // Order by the document's slide tree (authoritative); fall back to
+        // slide-archive id, then filename, when it can't be resolved.
+        let deck = Self.deckOrder(components: components, slideIDs: Set(slides.map(\.id)))
+        let rank = Dictionary(deck.enumerated().map { ($1, $0) }, uniquingKeysWith: { first, _ in first })
+        let ordered = slides.sorted { lhs, rhs in
+            let lr = rank[lhs.id] ?? Int.max
+            let rr = rank[rhs.id] ?? Int.max
+            if lr != rr { return lr < rr }
+            if lhs.id != rhs.id { return lhs.id < rhs.id }
+            return lhs.name < rhs.name
+        }
+
+        var sections: [DocumentSection] = []
+        for (index, slide) in ordered.enumerated() {
+            // slideNumber is the deck position, so skipping an empty slide leaves a
+            // gap rather than renumbering the slides after it.
+            guard !slide.text.isEmpty else { continue }
             sections.append(DocumentSection(
                 kind: .slide,
-                markdown: text,
+                markdown: slide.text,
                 sourcePath: slide.name,
                 slideNumber: index + 1
             ))
@@ -105,12 +119,38 @@ public struct KeynoteConverter: DocumentConverter {
         return base.hasPrefix("MasterSlide")
     }
 
-    /// The trailing slide number from the filename (`Slide12.iwa` → 12), for
-    /// ordering. Falls back to `Int.max` so unnumbered names sort last/stably.
-    static func slideOrder(_ path: String) -> Int {
-        let base = path.split(separator: "/").last.map(String.init) ?? path
-        let digits = base.drop { !$0.isNumber }.prefix { $0.isNumber }
-        return Int(digits) ?? Int.max
+    /// KN.SlideArchive message type — the slide object inside each `Slide*.iwa`,
+    /// whose identifier the document's slide tree references (confirmed against a
+    /// real `.key`).
+    static let slideArchiveType: UInt64 = 5
+
+    /// Resolves deck order from `Document.iwa`'s slide tree: each tree node
+    /// references one slide, and the tree references its nodes in order. Returns
+    /// slide ids in deck order, or empty if it can't be resolved (caller then
+    /// falls back to slide-id / filename order). Structural — it identifies the
+    /// tree and nodes via the reference graph rather than hard-coding their
+    /// message types; only the slide-archive type above is fixed.
+    private static func deckOrder(components: [Component], slideIDs: Set<UInt64>) -> [UInt64] {
+        guard !slideIDs.isEmpty,
+              let doc = components.first(where: { $0.name.hasSuffix("Document.iwa") }),
+              let stream = try? Snappy.decompressIWA(doc.bytes) else { return [] }
+        let objects = IWAArchive.objects(in: stream)
+        // A slide-tree node references exactly one slide; map node id -> slide id.
+        var nodeToSlide: [UInt64: UInt64] = [:]
+        for object in objects {
+            if let slideID = object.references.first(where: { slideIDs.contains($0) }) {
+                nodeToSlide[object.identifier] = slideID
+            }
+        }
+        guard !nodeToSlide.isEmpty else { return [] }
+        // The slide tree is the object referencing the most of those nodes; its
+        // node references, in order, give the deck order.
+        var orderedNodes: [UInt64] = []
+        for object in objects {
+            let nodes = object.references.filter { nodeToSlide[$0] != nil }
+            if nodes.count > orderedNodes.count { orderedNodes = nodes }
+        }
+        return orderedNodes.compactMap { nodeToSlide[$0] }
     }
 
     // MARK: - IWA gathering

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -10,11 +10,13 @@
 //
 //  Scope (v1): extracts the document's plain text (paragraphs) from the flat,
 //  single-file `.pages` ZIP — the common transport form (downloads, mail, Files
-//  exports). Rich structure (headings, styling, tables, footnotes, inline
-//  images), the legacy iWork '09 XML format, and ingesting a `.pages` *package
-//  directory* (an on-disk bundle, which the FileFetcher currently treats as a
-//  folder) are planned follow-ups; this converter raises a clear, actionable
-//  error for inputs it can't yet read rather than emitting nothing.
+//  exports) — plus table content, reconstructed as Markdown grids and appended
+//  after the body (see IWATable). Remaining rich structure (headings, styling,
+//  footnotes, inline images, inline table placement), the legacy iWork '09 XML
+//  format, and ingesting a `.pages` *package directory* (an on-disk bundle,
+//  which the FileFetcher currently treats as a folder) are planned follow-ups;
+//  this converter raises a clear, actionable error for inputs it can't yet read
+//  rather than emitting nothing.
 //
 //  Format references: obriensp/iWorkFileFormat, the SheetJS IWA notes, and
 //  Cocoanetics/SwiftText (MIT) — the in-module decode approach here is informed
@@ -46,41 +48,55 @@ public struct PagesConverter: DocumentConverter {
             throw PicoDocsError.documentTypeNotSupported
         }
 
-        // The main story lives in Document.iwa and is authoritative: if present it
-        // must decompress cleanly (corruption → fail), and its text — even if
-        // empty — determines the result, so we never scavenge stylesheet/header
-        // text from auxiliary components and pass it off as the body. Only when
-        // Document.iwa is absent do we fall back to a best-effort scan.
-        var bodyText = ""
-        if let main = components.first(where: { $0.name.hasSuffix("Document.iwa") }) {
+        // Decompress every component once. The main story (Document.iwa) is
+        // authoritative: if present it must decompress cleanly (corruption →
+        // fail) and its text — even if empty — is the body, so we never scavenge
+        // stylesheet/header text and pass it off as the body. Auxiliary
+        // components that fail to decompress are skipped leniently; they are
+        // still gathered whole for table reconstruction (tiles, datalists, and
+        // the table model live in separate Tables/*.iwa and CalculationEngine.iwa).
+        var streams: [(name: String, stream: [UInt8])] = []
+        var documentStream: [UInt8]?
+        for component in components {
             try Task.checkCancellation()
             do {
-                bodyText = IWAArchive.text(in: try Snappy.decompressIWA(main.bytes))
+                let stream = try Snappy.decompressIWA(component.bytes)
+                if component.name.hasSuffix("Document.iwa") { documentStream = stream }
+                streams.append((name: component.name, stream: stream))
             } catch {
-                throw PicoDocsError.fileCorrupted
-            }
-        } else {
-            for component in components.sorted(by: { $0.name < $1.name }) {
-                try Task.checkCancellation()
-                guard let stream = try? Snappy.decompressIWA(component.bytes) else { continue }
-                let extracted = IWAArchive.text(in: stream)
-                if !extracted.isEmpty {
-                    bodyText = extracted
-                    break
-                }
+                if component.name.hasSuffix("Document.iwa") { throw PicoDocsError.fileCorrupted }
             }
         }
 
-        let cleaned = Self.normalize(bodyText)
-        guard !cleaned.isEmpty else { throw PicoDocsError.emptyDocument }
+        // Body text: from Document.iwa if present, else the first component (by
+        // name) that yields any text.
+        let bodyText: String
+        if let documentStream {
+            bodyText = IWAArchive.text(in: documentStream)
+        } else {
+            var firstText = ""
+            for entry in streams.sorted(by: { $0.name < $1.name }) {
+                let extracted = IWAArchive.text(in: entry.stream)
+                if !extracted.isEmpty { firstText = extracted; break }
+            }
+            bodyText = firstText
+        }
 
-        let section = DocumentSection(
-            kind: .body,
-            markdown: cleaned,
-            sourcePath: "Index/Document.iwa"
-        )
+        // Tables are reconstructed from the whole component set and appended after
+        // the body as standalone sections (inline placement is a follow-up).
+        let cleaned = Self.normalize(bodyText)
+        let tables = IWATable.markdownTables(from: streams.map(\.stream))
+        guard !cleaned.isEmpty || !tables.isEmpty else { throw PicoDocsError.emptyDocument }
+
+        var sections: [DocumentSection] = []
+        if !cleaned.isEmpty {
+            sections.append(DocumentSection(kind: .body, markdown: cleaned, sourcePath: "Index/Document.iwa"))
+        }
+        for table in tables {
+            sections.append(DocumentSection(kind: .table, markdown: table, sourcePath: "Index/Tables"))
+        }
         let title = (info.filename?.isEmpty == false) ? info.filename : nil
-        return ConverterResult(title: title, sections: [section])
+        return ConverterResult(title: title, sections: sections)
     }
 
     // MARK: - IWA gathering

--- a/Tests/PicoDocsTests/KeynoteConverterTests.swift
+++ b/Tests/PicoDocsTests/KeynoteConverterTests.swift
@@ -114,4 +114,32 @@ struct KeynoteConverterTests {
             _ = try await KeynoteConverter().convert(key, info: info)
         }
     }
+
+    @Test("KeynoteConverter extracts deck-ordered slide text from a real .key, excluding presenter notes")
+    func realKeynoteFixture() async throws {
+        let data = try Fixture.data("sample", "key")
+        let result = try await PicoDocsEngine.convert(data: data, filename: "sample.key")
+
+        let slides = result.sections.filter { $0.kind == .slide }
+        #expect(slides.count == 3)
+        #expect(slides.map(\.slideNumber) == [1, 2, 3])
+
+        // Deck order comes from Document.iwa's slide tree, NOT the filenames:
+        // Slide.iwa ("The problem") is slide 2, not last. (Filename order would
+        // put it last and swap slides 2/3.)
+        #expect(slides[0].markdown.contains("The Spoon"))
+        #expect(slides[0].markdown.contains("Ronald Mannak"))
+        #expect(slides[1].markdown.contains("The problem"))
+        #expect(slides[1].markdown.contains("Every mug has a spoon-shaped absence"))
+        #expect(slides[2].markdown.contains("The data"))
+
+        // Presenter notes are kind 4 → excluded by the kind==0 filter; they must
+        // not leak into slide text.
+        let markdown = result.markdown()
+        #expect(!markdown.contains("Good morning. Thank you all"))
+        #expect(!markdown.contains("barista pea"))
+
+        // Object-replacement image placeholders are stripped.
+        #expect(!markdown.unicodeScalars.contains("\u{FFFC}"))
+    }
 }

--- a/Tests/PicoDocsTests/PagesConverterTests.swift
+++ b/Tests/PicoDocsTests/PagesConverterTests.swift
@@ -115,6 +115,28 @@ struct PagesConverterTests {
         #expect(!markdown.unicodeScalars.contains("\u{0004}"))
     }
 
+    @Test("PagesConverter reconstructs tables from a real Pages fixture")
+    func realPagesTables() async throws {
+        let data = try Fixture.data("sample", "pages")
+        let result = try await PicoDocsEngine.convert(data: data, filename: "sample.pages")
+        let tables = result.sections.filter { $0.kind == .table }
+
+        // Two content tables (5×4 and 4×6); two empty/placeholder tables are skipped.
+        #expect(tables.count == 2)
+
+        // Table 1: exact header row, plus a body row exercising empty cells.
+        #expect(tables.contains { $0.markdown.contains("| Feature | Expected import | Sample value | Notes |") })
+        #expect(tables.contains { $0.markdown.contains("| Empty cell |  |  | Importer should not crash |") })
+
+        // Table 2: exact header row across all six columns.
+        #expect(tables.contains {
+            $0.markdown.contains("| Column A | Column B | Column C | Column D | Column E | Column F |")
+        })
+
+        // GitHub-flavored separator row for the four-column table.
+        #expect(tables.contains { $0.markdown.contains("| --- | --- | --- | --- |") })
+    }
+
     @Test("Detector routes a .pages package to the Pages format")
     func detectionRoutesToPages() {
         let pages = Self.makePagesFile(paragraphs: ["Hi"])

--- a/Tests/PicoDocsTests/PagesConverterTests.swift
+++ b/Tests/PicoDocsTests/PagesConverterTests.swift
@@ -58,6 +58,27 @@ struct PagesConverterTests {
         #expect(IWAArchive.text(in: stream) == "real")
     }
 
+    @Test("IWAArchive captures the identifier regardless of ArchiveInfo field order")
+    func iwaIdentifierOrderIndependent() {
+        // Protobuf fields may be serialized in any order: an ArchiveInfo that
+        // emits message_infos (field 2) BEFORE identifier (field 1) must still
+        // attach the right id (it would be 0 if we trusted field order).
+        let payload = Array("body".utf8)
+        var storage: [UInt8] = []                         // TSWP.StorageArchive { text }
+        storage += Self.tag(field: 3, wire: 2) + Self.varint(UInt64(payload.count)) + payload
+        var messageInfo: [UInt8] = []                     // MessageInfo { type=2001; length }
+        messageInfo += Self.tag(field: 1, wire: 0) + Self.varint(2001)
+        messageInfo += Self.tag(field: 3, wire: 0) + Self.varint(UInt64(storage.count))
+        var archiveInfo: [UInt8] = []                     // field 2 before field 1
+        archiveInfo += Self.tag(field: 2, wire: 2) + Self.varint(UInt64(messageInfo.count)) + messageInfo
+        archiveInfo += Self.tag(field: 1, wire: 0) + Self.varint(4242)
+        var stream: [UInt8] = []
+        stream += Self.varint(UInt64(archiveInfo.count)) + archiveInfo + storage
+
+        #expect(IWAArchive.objects(in: stream).first?.identifier == 4242)
+        #expect(IWAArchive.text(in: stream) == "body")
+    }
+
     // MARK: - End to end
 
     @Test("PagesConverter extracts body text from a synthetic .pages package")


### PR DESCRIPTION
## Summary
This PR adds table reconstruction from Apple iWork documents and improves Keynote slide ordering by reading the document's slide tree. Tables are now extracted from Pages documents and rendered as GitHub-flavored Markdown grids, while Keynote slides are ordered according to the presentation's authoritative slide tree rather than filename order.

## Key Changes

### Table Reconstruction (IWATable.swift)
- **New module** that reconstructs text tables from decompressed IWA object streams
- Follows the document object graph to resolve three object kinds: `TableModelArchive` (table metadata), `Tile` (cell grid), and `DataList` (string store)
- Decodes cell records (marked with `05 09` bytes) to extract string keys, then resolves them through the string store to retrieve cell text
- Renders tables as GitHub-flavored Markdown with proper escaping for pipes, backslashes, and newlines
- Skips empty/placeholder tables and non-text cells (numeric/date/formula cells render as empty)

### Pages Converter Updates
- Decompresses all components once and passes the full stream set to `IWATable.markdownTables()`
- Tables are appended as separate sections after the body text (inline placement is a follow-up)
- Improved error handling: auxiliary components that fail to decompress are skipped leniently; only `Document.iwa` corruption is fatal
- Updated documentation to reflect table support

### Keynote Converter Improvements
- **Slide ordering now uses the document's authoritative slide tree** from `Document.iwa` instead of relying on filename order
- New `deckOrder()` method reconstructs the slide tree by identifying the object that references the most slide-tree nodes, then returns those nodes in order
- Falls back gracefully to slide-archive ID order, then filename order, when the slide tree can't be resolved
- Refactored to parse all slides once, capturing both their IDs and text, then sort by deck order
- Updated documentation to clarify that presenter notes (kind 4) are excluded by the `kind == 0` filter

### IWAArchive Enhancements
- **Object now includes `references` field** capturing `MessageInfo.object_references` for cross-object graph traversal
- Fixed identifier assignment to be field-order independent: `ArchiveInfo` now collects all `MessageInfo` entries first, then stamps them with the identifier (prevents identifier=0 when field 2 precedes field 1)
- Added `text(from:)` overload to extract text from already-parsed objects, avoiding re-parsing for callers that need both text and object metadata

## Notable Implementation Details

- **Protobuf field-order independence**: The `messageInfos()` parser now collects all message info entries before assigning the identifier, ensuring correct behavior regardless of whether field 1 or field 2 appears first in the serialized ArchiveInfo
- **Stable table ordering**: Tables are sorted by tile ID to provide consistent output across runs
- **Graceful degradation**: Empty tables, undecodable cells, and missing string references are silently skipped rather than failing the entire conversion
- **Markdown safety**: Cell text is escaped to prevent pipe characters and newlines from breaking table formatting

## Testing
- Added test for field-order independence in IWAArchive identifier assignment
- Added end-to-end test for table reconstruction from a real Pages fixture (two content tables with mixed empty cells and Unicode content)
- Added end-to-end test for Keynote slide ordering from a real `.key` fixture, verifying deck order matches the slide tree (not filename order) and presenter notes are excluded

https://claude.ai/code/session_01Mxnj6jvuLX9VS9JsJJbjmf