### PR TITLE
Place tables inline at attachment points in Pages documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Create a PR to include your app here.
 
 ## Known Limitations
 
-- **iWork table positioning**: Tables in Pages and Keynote documents are extracted and appended after the document body rather than placed inline at their original position in the text. Restoring inline table placement is planned for a future release.
+- **iWork tables**: In Pages, tables are reconstructed and placed inline at their original position in the text (falling back to appending them after the body when their anchor can't be resolved). Non-text cells (numbers, dates, formulas) currently render as empty, and Keynote table extraction is not yet implemented.
 
 ## License
 

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -39,56 +39,168 @@ enum IWATable {
     private static let storageType: UInt64 = 2001
     private static let tableModelTypes: Set<UInt64> = [6001, 6316]   // TST.TableModelArchive
 
-    /// Reconstructs every text table found across the given decompressed IWA
-    /// streams, rendered as Markdown, ordered by tile identifier (a stable proxy
-    /// for document order). Best-effort: undecodable or empty tables are skipped,
-    /// so a document with no tables simply yields `[]`.
+    /// One ordered piece of a converted body — a run of text or a reconstructed
+    /// table, in reading order. Text is raw; the caller normalizes it.
+    enum Block: Equatable {
+        case text(String)
+        case table(String)
+    }
+
+    /// Every text table across the given decompressed IWA streams, rendered as
+    /// Markdown and ordered by tile identifier (a stable proxy for document
+    /// order). This is the appended-table fallback; `inlineBlocks` instead places
+    /// tables at their attachment points. Best-effort: a document with no tables
+    /// yields `[]`.
     static func markdownTables(from streams: [[UInt8]]) -> [String] {
-        // A table model lives in CalculationEngine.iwa but references tiles and
-        // datalists in Tables/*.iwa, so the whole document is indexed by id.
+        let byTile = reconstructTables(buildObjects(streams))
+        return byTile.keys.sorted().compactMap { byTile[$0] }
+    }
+
+    /// Splits the document body into ordered text/table blocks, placing each
+    /// reconstructed table inline at its ￼ (U+FFFC) attachment position. Returns
+    /// nil — so the caller can fall back to appended tables — unless every
+    /// reconstructed table is cleanly placed (e.g. it bails on a count mismatch
+    /// between ￼ markers and attachment runs), so a table is never dropped.
+    static func inlineBlocks(documentStream: [UInt8], in streams: [[UInt8]]) -> [Block]? {
+        let objects = buildObjects(streams)
+        let tableMarkdown = reconstructTables(objects)
+        guard !tableMarkdown.isEmpty else { return nil }
+        let tiles = Set(tableMarkdown.keys)
+
+        var blocks: [Block] = []
+        var placed = Set<UInt64>()
+        // Body storages in document (stream) order; each carries its own text
+        // (field 3) and drawable attachment runs (field 9).
+        for storage in IWAArchive.objects(in: documentStream) where storage.type == storageType {
+            guard let text = bodyStorageText(storage) else { continue }    // kind 0 only
+            let runs = attachmentRuns(in: storage)
+            let markers = text.indices.filter { text[$0] == "\u{FFFC}" }
+            guard markers.count == runs.count else { return nil }          // can't map 1:1
+
+            var buffer = ""
+            var segmentStart = text.startIndex
+            for (marker, run) in zip(markers, runs) {
+                buffer += String(text[segmentStart..<marker])
+                segmentStart = text.index(after: marker)                   // always drop the ￼
+                guard let tile = reachableTile(from: run.objectID, objects: objects, tiles: tiles),
+                      let markdown = tableMarkdown[tile] else { continue }  // non-table (image): merge text
+                if !buffer.isEmpty { blocks.append(.text(buffer)); buffer = "" }
+                blocks.append(.table(markdown))
+                placed.insert(tile)
+            }
+            buffer += String(text[segmentStart...])
+            if !buffer.isEmpty { blocks.append(.text(buffer)) }
+        }
+        // Commit to inline layout only if every reconstructed table found a home.
+        return placed == tiles ? blocks : nil
+    }
+
+    // MARK: - Object graph
+
+    private static func buildObjects(_ streams: [[UInt8]]) -> [UInt64: IWAArchive.Object] {
         var objects: [UInt64: IWAArchive.Object] = [:]
         for stream in streams {
-            for object in IWAArchive.objects(in: stream) {
-                objects[object.identifier] = object
-            }
+            for object in IWAArchive.objects(in: stream) { objects[object.identifier] = object }
         }
-        guard !objects.isEmpty else { return [] }
+        return objects
+    }
 
+    /// Maps each content table's tile id to its rendered Markdown. A table model
+    /// (6001/6316) references exactly one tile and the datalist holding its
+    /// strings; restricting to those types avoids mistaking an unrelated object
+    /// that references both for a table.
+    private static func reconstructTables(_ objects: [UInt64: IWAArchive.Object]) -> [UInt64: String] {
         let tileIDs = Set(objects.values.filter { $0.type == tileType }.map(\.identifier))
-        guard !tileIDs.isEmpty else { return [] }
+        guard !tileIDs.isEmpty else { return [:] }
 
-        // Resolve every non-empty string DataList to key -> text.
         var stringLists: [UInt64: [UInt32: String]] = [:]
         for object in objects.values where object.type == dataListType {
             if let map = stringList(object, objects: objects), !map.isEmpty {
                 stringLists[object.identifier] = map
             }
         }
-        guard !stringLists.isEmpty else { return [] }
+        guard !stringLists.isEmpty else { return [:] }
 
-        // A table model references exactly one tile and the datalist holding its
-        // strings. Restrict to the known table-model types so an unrelated object
-        // that happens to reference both can't be mistaken for a table. Collect
-        // (tile, strings) pairs, then render once per tile in a stable order
-        // (Dictionary iteration order is unspecified).
-        var pairs: [(tile: UInt64, strings: UInt64)] = []
+        var byTile: [UInt64: String] = [:]
         for object in objects.values where tableModelTypes.contains(object.type) {
             guard let tile = object.references.first(where: { tileIDs.contains($0) }),
-                  let strings = object.references.first(where: { stringLists[$0] != nil }) else { continue }
-            pairs.append((tile, strings))
-        }
-        pairs.sort { $0.tile < $1.tile }
-
-        var tables: [String] = []
-        var seenTiles = Set<UInt64>()
-        for pair in pairs {
-            guard seenTiles.insert(pair.tile).inserted,
-                  let tile = objects[pair.tile], let strings = stringLists[pair.strings] else { continue }
-            if let markdown = render(grid: cellKeyGrid(tile), strings: strings) {
-                tables.append(markdown)
+                  let strings = object.references.first(where: { stringLists[$0] != nil }),
+                  byTile[tile] == nil,
+                  let tileObject = objects[tile], let stringMap = stringLists[strings] else { continue }
+            if let markdown = render(grid: cellKeyGrid(tileObject), strings: stringMap) {
+                byTile[tile] = markdown
             }
         }
-        return tables
+        return byTile
+    }
+
+    // MARK: - Inline attachments
+
+    /// A body storage's drawable attachment runs (field 9, a wrapper of repeated
+    /// runs), sorted by character index. Each run pairs a ￼ with the attached
+    /// object's id; for a table that object (TSWP attachment, type 2003) leads on
+    /// to the TableInfo → model → tile.
+    private static func attachmentRuns(in storage: IWAArchive.Object) -> [(charIndex: Int, objectID: UInt64)] {
+        var runs: [(charIndex: Int, objectID: UInt64)] = []
+        var reader = ProtobufReader(storage.payload)
+        while let field = reader.next() {
+            guard field.number == 9, case .length(let wrapper) = field.value else { continue }
+            var wrapperReader = ProtobufReader(wrapper)
+            while let entry = wrapperReader.next() {
+                guard entry.number == 1, case .length(let runBytes) = entry.value else { continue }
+                var charIndex: Int?
+                var objectID: UInt64?
+                var runReader = ProtobufReader(runBytes)
+                while let runField = runReader.next() {
+                    switch (runField.number, runField.value) {
+                    case (1, .varint(let index)): charIndex = Int(index)
+                    case (2, .length(let reference)): objectID = referencedID(in: reference)
+                    default: continue
+                    }
+                }
+                if let charIndex, let objectID { runs.append((charIndex, objectID)) }
+            }
+        }
+        return runs.sorted { $0.charIndex < $1.charIndex }
+    }
+
+    /// Bounded breadth-first walk from an attachment object to a referenced tile
+    /// (2003 → TableInfo 6000 → model 6001/6316 → tile 6002), returning the first
+    /// tile that has a reconstructed table — or nil (e.g. for an image).
+    private static func reachableTile(from start: UInt64, objects: [UInt64: IWAArchive.Object],
+                                      tiles: Set<UInt64>) -> UInt64? {
+        var frontier = [start]
+        var visited: Set<UInt64> = [start]
+        for _ in 0..<5 {
+            var next: [UInt64] = []
+            for id in frontier {
+                guard let object = objects[id] else { continue }
+                for reference in object.references {
+                    if tiles.contains(reference) { return reference }
+                    if visited.insert(reference).inserted { next.append(reference) }
+                }
+            }
+            if next.isEmpty { break }
+            frontier = next
+        }
+        return nil
+    }
+
+    /// A storage's body text (concatenated `repeated string text`, field 3) when
+    /// it's a body storage (`kind` 0 or absent); nil for header/footer/etc.
+    private static func bodyStorageText(_ storage: IWAArchive.Object) -> String? {
+        var kind: UInt64 = 0
+        var runs: [String] = []
+        var reader = ProtobufReader(storage.payload)
+        while let field = reader.next() {
+            switch (field.number, field.value) {
+            case (1, .varint(let value)): kind = value
+            case (3, .length(let bytes)):
+                if let run = String(bytes: bytes, encoding: .utf8) { runs.append(run) }
+            default: continue
+            }
+        }
+        return kind == 0 ? runs.joined() : nil
     }
 
     // MARK: - DataList (string store)

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -155,7 +155,7 @@ enum IWATable {
                 var runReader = ProtobufReader(runBytes)
                 while let runField = runReader.next() {
                     switch (runField.number, runField.value) {
-                    case (1, .varint(let index)): charIndex = Int(index)
+                    case (1, .varint(let index)): charIndex = Int(exactly: index)   // nil (skip run) on overflow
                     case (2, .length(let reference)): objectID = referencedID(in: reference)
                     default: continue
                     }

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -64,7 +64,9 @@ enum IWATable {
     static func inlineBlocks(documentStream: [UInt8], in streams: [[UInt8]]) -> [Block]? {
         let objects = buildObjects(streams)
         let tableMarkdown = reconstructTables(objects)
-        guard !tableMarkdown.isEmpty else { return nil }
+        // No early return on an empty table set: a table-less document still
+        // resolves to text-only blocks below, so the caller can use them directly
+        // instead of re-parsing the whole object graph in the appended fallback.
         let tiles = Set(tableMarkdown.keys)
 
         var blocks: [Block] = []
@@ -189,18 +191,19 @@ enum IWATable {
     /// A storage's body text (concatenated `repeated string text`, field 3) when
     /// it's a body storage (`kind` 0 or absent); nil for header/footer/etc.
     private static func bodyStorageText(_ storage: IWAArchive.Object) -> String? {
-        var kind: UInt64 = 0
         var runs: [String] = []
         var reader = ProtobufReader(storage.payload)
         while let field = reader.next() {
             switch (field.number, field.value) {
-            case (1, .varint(let value)): kind = value
+            case (1, .varint(let kind)):
+                guard kind == 0 else { return nil }   // header/footer/etc.: skip without decoding the rest
             case (3, .length(let bytes)):
                 if let run = String(bytes: bytes, encoding: .utf8) { runs.append(run) }
-            default: continue
+            default:
+                continue
             }
         }
-        return kind == 0 ? runs.joined() : nil
+        return runs.joined()
     }
 
     // MARK: - DataList (string store)

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -10,12 +10,14 @@
 //
 //  Scope (v1): extracts the document's plain text (paragraphs) from the flat,
 //  single-file `.pages` ZIP — the common transport form (downloads, mail, Files
-//  exports) — plus table content, reconstructed as Markdown grids and appended
-//  after the body (see IWATable). Remaining rich structure (headings, styling,
-//  footnotes, inline images, inline table placement), the legacy iWork '09 XML
-//  format, and ingesting a `.pages` *package directory* (an on-disk bundle,
-//  which the FileFetcher currently treats as a folder) are planned follow-ups;
-//  this converter raises a clear, actionable error for inputs it can't yet read
+//  exports) — plus table content, reconstructed as Markdown grids and placed
+//  inline at their attachment points in reading order (falling back to appending
+//  them after the body when attachments can't be mapped 1:1; see IWATable).
+//  Remaining rich structure (headings, styling, footnotes, inline images),
+//  non-text table cells (numbers/dates), the legacy iWork '09 XML format, and
+//  ingesting a `.pages` *package directory* (an on-disk bundle, which the
+//  FileFetcher currently treats as a folder) are planned follow-ups; this
+//  converter raises a clear, actionable error for inputs it can't yet read
 //  rather than emitting nothing.
 //
 //  Format references: obriensp/iWorkFileFormat, the SheetJS IWA notes, and
@@ -68,33 +70,49 @@ public struct PagesConverter: DocumentConverter {
             }
         }
 
-        // Body text: from Document.iwa if present, else the first component (by
-        // name) that yields any text.
-        let bodyText: String
-        if let documentStream {
-            bodyText = IWAArchive.text(in: documentStream)
-        } else {
-            var firstText = ""
-            for entry in streams.sorted(by: { $0.name < $1.name }) {
-                let extracted = IWAArchive.text(in: entry.stream)
-                if !extracted.isEmpty { firstText = extracted; break }
-            }
-            bodyText = firstText
-        }
-
-        // Tables are reconstructed from the whole component set and appended after
-        // the body as standalone sections (inline placement is a follow-up).
-        let cleaned = Self.normalize(bodyText)
-        let tables = IWATable.markdownTables(from: streams.map(\.stream))
-        guard !cleaned.isEmpty || !tables.isEmpty else { throw PicoDocsError.emptyDocument }
-
+        let allStreams = streams.map(\.stream)
         var sections: [DocumentSection] = []
-        if !cleaned.isEmpty {
-            sections.append(DocumentSection(kind: .body, markdown: cleaned, sourcePath: "Index/Document.iwa"))
+
+        // Prefer inline layout: tables placed at their ￼ attachment points, in
+        // reading order. Falls back to body text + tables appended after it when
+        // the attachments can't be mapped 1:1 (so a table is never dropped).
+        if let documentStream,
+           let blocks = IWATable.inlineBlocks(documentStream: documentStream, in: allStreams) {
+            for block in blocks {
+                switch block {
+                case .text(let raw):
+                    let cleaned = Self.normalize(raw)
+                    if !cleaned.isEmpty {
+                        sections.append(DocumentSection(kind: .body, markdown: cleaned, sourcePath: "Index/Document.iwa"))
+                    }
+                case .table(let markdown):
+                    sections.append(DocumentSection(kind: .table, markdown: markdown, sourcePath: "Index/Tables"))
+                }
+            }
+        } else {
+            // Body text: from Document.iwa if present, else the first component (by
+            // name) that yields any text.
+            let bodyText: String
+            if let documentStream {
+                bodyText = IWAArchive.text(in: documentStream)
+            } else {
+                var firstText = ""
+                for entry in streams.sorted(by: { $0.name < $1.name }) {
+                    let extracted = IWAArchive.text(in: entry.stream)
+                    if !extracted.isEmpty { firstText = extracted; break }
+                }
+                bodyText = firstText
+            }
+            let cleaned = Self.normalize(bodyText)
+            if !cleaned.isEmpty {
+                sections.append(DocumentSection(kind: .body, markdown: cleaned, sourcePath: "Index/Document.iwa"))
+            }
+            for markdown in IWATable.markdownTables(from: allStreams) {
+                sections.append(DocumentSection(kind: .table, markdown: markdown, sourcePath: "Index/Tables"))
+            }
         }
-        for table in tables {
-            sections.append(DocumentSection(kind: .table, markdown: table, sourcePath: "Index/Tables"))
-        }
+
+        guard !sections.isEmpty else { throw PicoDocsError.emptyDocument }
         let title = (info.filename?.isEmpty == false) ? info.filename : nil
         return ConverterResult(title: title, sections: sections)
     }

--- a/Tests/PicoDocsTests/PagesConverterTests.swift
+++ b/Tests/PicoDocsTests/PagesConverterTests.swift
@@ -137,6 +137,36 @@ struct PagesConverterTests {
         #expect(tables.contains { $0.markdown.contains("| --- | --- | --- | --- |") })
     }
 
+    @Test("PagesConverter places tables inline at their attachment points, in reading order")
+    func realPagesTablesInline() async throws {
+        let data = try Fixture.data("sample", "pages")
+        let result = try await PicoDocsEngine.convert(data: data, filename: "sample.pages")
+        let kinds = result.sections.map(\.kind)
+
+        // Tables are interleaved with the body, not all appended at the end: a
+        // body section follows the first table section.
+        let firstTable = kinds.firstIndex(of: .table)
+        #expect(firstTable != nil)
+        if let firstTable {
+            #expect(kinds[(firstTable + 1)...].contains(.body))
+        }
+
+        // Reading order in the rendered Markdown: intro text → Table 1 → Table 2
+        // → end marker. (In the appended fallback the end marker would precede the
+        // tables, so this also asserts the inline path is taken.)
+        let markdown = result.markdown()
+        let intro = markdown.range(of: "Representative Import Fixture for Apple Pages")
+        let table1 = markdown.range(of: "| Feature | Expected import | Sample value | Notes |")
+        let table2 = markdown.range(of: "| Column A | Column B | Column C | Column D | Column E | Column F |")
+        let endMarker = markdown.range(of: "END_OF_PAGES_IMPORT_FIXTURE")
+        #expect(intro != nil && table1 != nil && table2 != nil && endMarker != nil)
+        if let intro, let table1, let table2, let endMarker {
+            #expect(intro.lowerBound < table1.lowerBound)
+            #expect(table1.lowerBound < table2.lowerBound)
+            #expect(table2.lowerBound < endMarker.lowerBound)
+        }
+    }
+
     @Test("Detector routes a .pages package to the Pages format")
     func detectionRoutesToPages() {
         let pages = Self.makePagesFile(paragraphs: ["Hi"])


### PR DESCRIPTION
## Summary
Implements inline table placement in Pages documents by mapping tables to their attachment points (U+FFFC markers) in the document body, rather than always appending them after the text. Falls back to the appended-table approach when attachments can't be cleanly mapped 1:1, ensuring no tables are dropped.

## Key Changes

- **New `Block` enum in `IWATable`**: Represents ordered document pieces (text runs or tables) for inline layout
- **`inlineBlocks()` method**: Splits document body into text/table blocks, placing each reconstructed table at its U+FFFC attachment position in reading order. Returns `nil` to trigger fallback if any table can't be placed
- **`attachmentRuns()` helper**: Extracts drawable attachment runs from body storage (field 9), mapping character indices to attached object IDs
- **`reachableTile()` helper**: Performs bounded BFS from an attachment object through the object graph (2003 → TableInfo 6000 → model 6001/6316 → tile 6002) to find referenced tables
- **`bodyStorageText()` helper**: Extracts body text from storage objects, filtering for body kind (0) only
- **Refactored `markdownTables()`**: Now delegates to extracted `buildObjects()` and `reconstructTables()` helpers for cleaner separation of concerns
- **Updated `PagesConverter`**: Prefers inline layout via `inlineBlocks()`, falling back to appended tables when inline mapping fails
- **New test**: Verifies tables are interleaved with body text in reading order (intro → Table 1 → Table 2 → end marker)

## Implementation Details

- Attachment mapping is strict: bails if the count of U+FFFC markers doesn't match attachment runs, preventing silent table drops
- Non-table attachments (e.g., images) are skipped during inline placement; their markers are simply removed from the text
- The fallback to appended tables is transparent to the caller—if inline placement fails for any reason, the document still renders with tables at the end
- Object graph traversal is bounded to 5 hops to prevent infinite loops while allowing the typical 4-hop path (attachment → TableInfo → model → tile)

https://claude.ai/code/session_01Mxnj6jvuLX9VS9JsJJbjmf