### PR TITLE
Add date cell support and inline-text tables for iWork

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Create a PR to include your app here.
 
 ## Known Limitations
 
-- **iWork tables**: In Pages, tables are reconstructed and placed inline at their original position in the text (falling back to appending them after the body when their anchor can't be resolved). Non-text cells (numbers, dates, formulas) currently render as empty, and Keynote table extraction is not yet implemented.
+- **iWork tables**: Tables are reconstructed as Markdown grids — placed inline at their original position in Pages, and appended after the slides in Keynote (per-slide placement is a follow-up). Text and date cells are decoded; number, duration, and formula cells currently render as empty.
 
 ## License
 

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -13,19 +13,20 @@
 //      columns (one per aspect: strings, formats, styles, …).
 //    • TST.Tile (type 6002) — the cell grid: `repeated TileRowInfo` (field 5),
 //      each row carrying a packed cell buffer (field 6) and a uint16 offset
-//      array (field 7). A string cell record begins with the bytes `05 09` and
-//      stores its string key as a little-endian uint32 at byte offset 12.
-//    • TST.DataList (type 6005) with `list_type == 8` (field 1) — the string
-//      store: `repeated entry` (field 3) mapping a key (field 1) to a
-//      RichTextPayload reference (field 9 → type 6218 → type 2001
-//      TSWP.StorageArchive, whose `repeated string text` is the cell text).
+//      array (field 7). A cell record begins `05 <value-type>`; the value-type
+//      byte selects how to read offset +12: rich text key (0x09), inline text
+//      key (0x03), or a date as a double in seconds since 2001-01-01 (0x05).
+//    • TST.DataList (type 6005) — the cell-value store, two flavors keyed by
+//      `list_type` (field 1): rich text (`8`) maps a key (entry field 1) to a
+//      RichTextPayload (entry field 9 → 6218 → 2001 TSWP.StorageArchive); inline
+//      text (`1`) stores the string directly in the entry (field 3, Keynote).
 //
-//  Confirmed against a real `.pages` fixture (two text tables, 5×4 and 4×6,
-//  including empty cells and Unicode/URL content).
+//  Confirmed against real `.pages` and `.key` fixtures (text + date cells).
 //
-//  Scope (v1): text cells only — numeric/date/formula cells render as empty
-//  cells. Tables are emitted as standalone sections appended after the body
-//  rather than positioned inline at their attachment point (see README).
+//  Scope: text and date cells; number, duration, and formula cells aren't
+//  decoded yet and render empty. For Pages, tables are placed inline at their
+//  attachment point (see PagesConverter); for Keynote they're appended after the
+//  slides.
 //
 
 import Foundation
@@ -38,6 +39,13 @@ enum IWATable {
     private static let richTextPayloadType: UInt64 = 6218
     private static let storageType: UInt64 = 2001
     private static let tableModelTypes: Set<UInt64> = [6001, 6316]   // TST.TableModelArchive
+    private static let inlineListType: UInt64 = 1        // DataList.list_type for inline cell text
+    // Cell record value-type byte (record offset 1): rich text (key → f1==8 list),
+    // inline text (key → f1==1 list), and date (double, seconds since 2001-01-01,
+    // at offset +12). Number/duration/formula cells aren't decoded yet.
+    private static let richTextCell: UInt8 = 0x09
+    private static let inlineTextCell: UInt8 = 0x03
+    private static let dateCell: UInt8 = 0x05
 
     /// One ordered piece of a converted body — a run of text or a reconstructed
     /// table, in reading order. Text is raw; the caller normalizes it.
@@ -108,28 +116,28 @@ enum IWATable {
     }
 
     /// Maps each content table's tile id to its rendered Markdown. A table model
-    /// (6001/6316) references exactly one tile and the datalist holding its
-    /// strings; restricting to those types avoids mistaking an unrelated object
-    /// that references both for a table.
+    /// (6001/6316) references its tile plus the datalists backing the cells: a
+    /// rich-text list (`f1==8`, via RichTextPayload → Storage) and/or an
+    /// inline-text list (`f1==1`, text stored directly in the entry). Cells choose
+    /// between them by value type; dates live in the cell record itself.
     private static func reconstructTables(_ objects: [UInt64: IWAArchive.Object]) -> [UInt64: String] {
         let tileIDs = Set(objects.values.filter { $0.type == tileType }.map(\.identifier))
         guard !tileIDs.isEmpty else { return [:] }
 
-        var stringLists: [UInt64: [UInt32: String]] = [:]
+        var richMaps: [UInt64: [UInt32: String]] = [:]
+        var inlineMaps: [UInt64: [UInt32: String]] = [:]
         for object in objects.values where object.type == dataListType {
-            if let map = stringList(object, objects: objects), !map.isEmpty {
-                stringLists[object.identifier] = map
-            }
+            if let map = richTextMap(object, objects: objects) { richMaps[object.identifier] = map }
+            else if let map = inlineTextMap(object) { inlineMaps[object.identifier] = map }
         }
-        guard !stringLists.isEmpty else { return [:] }
 
         var byTile: [UInt64: String] = [:]
         for object in objects.values where tableModelTypes.contains(object.type) {
-            guard let tile = object.references.first(where: { tileIDs.contains($0) }),
-                  let strings = object.references.first(where: { stringLists[$0] != nil }),
-                  byTile[tile] == nil,
-                  let tileObject = objects[tile], let stringMap = stringLists[strings] else { continue }
-            if let markdown = render(grid: cellKeyGrid(tileObject), strings: stringMap) {
+            guard let tile = object.references.first(where: { tileIDs.contains($0) }), byTile[tile] == nil,
+                  let tileObject = objects[tile] else { continue }
+            let rich = object.references.compactMap { richMaps[$0] }.first ?? [:]
+            let inline = object.references.compactMap { inlineMaps[$0] }.first ?? [:]
+            if let markdown = render(grid: cellGrid(tileObject, rich: rich, inline: inline)) {
                 byTile[tile] = markdown
             }
         }
@@ -208,11 +216,12 @@ enum IWATable {
 
     // MARK: - DataList (string store)
 
-    /// For a `list_type == 8` DataList, resolves entry key -> text by following
-    /// each entry's RichTextPayload reference (6218) to its TSWP.StorageArchive
-    /// (2001). Returns nil for non-string lists. Field order independent.
-    private static func stringList(_ object: IWAArchive.Object,
-                                   objects: [UInt64: IWAArchive.Object]) -> [UInt32: String]? {
+    /// Resolves a rich-text DataList (`list_type == 8`): entry key → text by
+    /// following the RichTextPayload reference (field 9 → type 6218) to its
+    /// TSWP.StorageArchive (2001). Returns nil for other list types or no text.
+    /// Field-order independent.
+    private static func richTextMap(_ object: IWAArchive.Object,
+                                    objects: [UInt64: IWAArchive.Object]) -> [UInt32: String]? {
         var listType: UInt64?
         var entries: [(key: UInt32, payload: UInt64)] = []
         var reader = ProtobufReader(object.payload)
@@ -226,7 +235,7 @@ enum IWATable {
                 continue
             }
         }
-        guard let listType, listType == stringListType else { return nil }
+        guard listType == stringListType else { return nil }
 
         var map: [UInt32: String] = [:]
         for entry in entries {
@@ -235,7 +244,38 @@ enum IWATable {
                   let storage = objects[storageID], storage.type == storageType else { continue }
             map[entry.key] = storageText(storage.payload)
         }
-        return map
+        return map.isEmpty ? nil : map
+    }
+
+    /// Resolves an inline-text DataList (`list_type == 1`): entry key → text stored
+    /// directly in the entry (field 3). Keynote tables (and some Pages cells) use
+    /// this instead of the rich-text list. Returns nil for other types or no text.
+    private static func inlineTextMap(_ object: IWAArchive.Object) -> [UInt32: String]? {
+        var listType: UInt64?
+        var map: [UInt32: String] = [:]
+        var reader = ProtobufReader(object.payload)
+        while let field = reader.next() {
+            switch (field.number, field.value) {
+            case (1, .varint(let type)):
+                listType = type
+            case (3, .length(let entryBytes)):
+                var key: UInt32?
+                var text: String?
+                var entryReader = ProtobufReader(entryBytes)
+                while let entryField = entryReader.next() {
+                    switch (entryField.number, entryField.value) {
+                    case (1, .varint(let k)): key = UInt32(truncatingIfNeeded: k)
+                    case (3, .length(let bytes)): text = String(bytes: bytes, encoding: .utf8)
+                    default: continue
+                    }
+                }
+                if let key, let text { map[key] = text }
+            default:
+                continue
+            }
+        }
+        guard listType == inlineListType else { return nil }
+        return map.isEmpty ? nil : map
     }
 
     /// One DataList entry: key (field 1) + RichTextPayload id (field 9 → field 1).
@@ -291,14 +331,15 @@ enum IWATable {
 
     // MARK: - Tile (cell grid)
 
-    /// Decodes a Tile into a grid of per-cell string keys (nil = empty or
-    /// non-text cell). Trailing empty columns are trimmed per row.
-    private static func cellKeyGrid(_ tile: IWAArchive.Object) -> [[UInt32?]] {
-        var rows: [[UInt32?]] = []
+    /// Decodes a Tile into a grid of rendered cell strings (nil = absent cell).
+    /// Trailing absent columns are trimmed per row.
+    private static func cellGrid(_ tile: IWAArchive.Object,
+                                 rich: [UInt32: String], inline: [UInt32: String]) -> [[String?]] {
+        var rows: [[String?]] = []
         var reader = ProtobufReader(tile.payload)
         while let field = reader.next() {
             if field.number == 5, case .length(let rowBytes) = field.value {
-                rows.append(cellKeys(inRow: rowBytes))
+                rows.append(cellTexts(inRow: rowBytes, rich: rich, inline: inline))
             }
         }
         return rows
@@ -306,7 +347,8 @@ enum IWATable {
 
     /// One TileRowInfo: uint16 offsets (field 7) into the cell buffer (field 6);
     /// 0xFFFF marks an absent cell.
-    private static func cellKeys(inRow rowBytes: [UInt8]) -> [UInt32?] {
+    private static func cellTexts(inRow rowBytes: [UInt8],
+                                  rich: [UInt32: String], inline: [UInt32: String]) -> [String?] {
         var buffer: [UInt8] = []
         var offsets: [UInt8] = []
         var reader = ProtobufReader(rowBytes)
@@ -317,40 +359,72 @@ enum IWATable {
             default: continue
             }
         }
-        var keys: [UInt32?] = []
+        var cells: [String?] = []
         var i = 0
         while i + 1 < offsets.count {
             let offset = Int(offsets[i]) | (Int(offsets[i + 1]) << 8)
             i += 2
-            keys.append(offset == 0xFFFF ? nil : stringKey(inCell: buffer, at: offset))
+            cells.append(offset == 0xFFFF ? nil : cellText(in: buffer, at: offset, rich: rich, inline: inline))
         }
-        while let last = keys.last, last == nil { keys.removeLast() }   // trim trailing empties
-        return keys
+        while let last = cells.last, last == nil { cells.removeLast() }   // trim trailing absent cells
+        return cells
     }
 
-    /// The string key stored in a cell record, or nil if it isn't a string cell
-    /// (`05 09` marker) or would read out of bounds. The key is a little-endian
-    /// uint32 at byte offset 12.
-    private static func stringKey(inCell buffer: [UInt8], at offset: Int) -> UInt32? {
-        guard offset >= 0, offset + 16 <= buffer.count,
-              buffer[offset] == 0x05, buffer[offset + 1] == 0x09 else { return nil }
-        let k = offset + 12
-        return UInt32(buffer[k]) | (UInt32(buffer[k + 1]) << 8)
-            | (UInt32(buffer[k + 2]) << 16) | (UInt32(buffer[k + 3]) << 24)
+    /// The rendered text of a cell record (`05 <type> …`): rich or inline text via
+    /// the string maps (key is a little-endian uint32 at +12), or a date (double,
+    /// seconds since 2001-01-01, at +12). Number/duration/formula cells aren't
+    /// decoded yet and render as "". Returns "" (a present-but-empty cell) on any
+    /// unhandled type or out-of-bounds read.
+    private static func cellText(in buffer: [UInt8], at offset: Int,
+                                 rich: [UInt32: String], inline: [UInt32: String]) -> String {
+        guard offset >= 0, offset + 2 <= buffer.count, buffer[offset] == 0x05 else { return "" }
+        switch buffer[offset + 1] {
+        case richTextCell:
+            guard let key = readUInt32(buffer, at: offset + 12) else { return "" }
+            return cleanCell(rich[key] ?? "")
+        case inlineTextCell:
+            guard let key = readUInt32(buffer, at: offset + 12) else { return "" }
+            return cleanCell(inline[key] ?? "")
+        case dateCell:
+            guard let seconds = readDouble(buffer, at: offset + 12) else { return "" }
+            return isoDate(seconds)
+        default:
+            return ""
+        }
+    }
+
+    private static func readUInt32(_ buffer: [UInt8], at offset: Int) -> UInt32? {
+        guard offset >= 0, offset + 4 <= buffer.count else { return nil }
+        return UInt32(buffer[offset]) | (UInt32(buffer[offset + 1]) << 8)
+            | (UInt32(buffer[offset + 2]) << 16) | (UInt32(buffer[offset + 3]) << 24)
+    }
+
+    private static func readDouble(_ buffer: [UInt8], at offset: Int) -> Double? {
+        guard offset >= 0, offset + 8 <= buffer.count else { return nil }
+        var bits: UInt64 = 0
+        for k in 0 ..< 8 { bits |= UInt64(buffer[offset + k]) << (8 * k) }
+        return Double(bitPattern: bits)
+    }
+
+    /// Formats seconds-since-2001 (iWork's reference date) as `yyyy-MM-dd` in UTC.
+    /// Implausible magnitudes return "".
+    private static func isoDate(_ secondsSinceReference: Double) -> String {
+        guard secondsSinceReference.isFinite, abs(secondsSinceReference) < 4e11 else { return "" }
+        let date = Date(timeIntervalSinceReferenceDate: secondsSinceReference)
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
     }
 
     // MARK: - Markdown rendering
 
-    /// Renders a key grid + string map as a GitHub-flavored Markdown table (first
-    /// row is the header). Returns nil if there are no columns or no resolvable
-    /// text, so empty/placeholder tables are skipped.
-    private static func render(grid: [[UInt32?]], strings: [UInt32: String]) -> String? {
-        let rows: [[String]] = grid.map { row in
-            row.map { key in
-                guard let key, let text = strings[key] else { return "" }
-                return cleanCell(text)
-            }
-        }
+    /// Renders a grid of cell strings as a GitHub-flavored Markdown table (first
+    /// row is the header). Returns nil if there are no columns or no non-empty
+    /// cell, so empty/placeholder tables are skipped.
+    private static func render(grid: [[String?]]) -> String? {
+        let rows: [[String]] = grid.map { row in row.map { $0 ?? "" } }
         let columnCount = rows.map(\.count).max() ?? 0
         guard columnCount > 0,
               rows.contains(where: { $0.contains { !$0.isEmpty } }) else { return nil }

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -127,8 +127,18 @@ enum IWATable {
         var richMaps: [UInt64: [UInt32: String]] = [:]
         var inlineMaps: [UInt64: [UInt32: String]] = [:]
         for object in objects.values where object.type == dataListType {
-            if let map = richTextMap(object, objects: objects) { richMaps[object.identifier] = map }
-            else if let map = inlineTextMap(object) { inlineMaps[object.identifier] = map }
+            // Dispatch on list_type (field 1) so each datalist's entries are fully
+            // parsed at most once — rich and inline text are mutually exclusive.
+            var listType: UInt64?
+            var reader = ProtobufReader(object.payload)
+            while let field = reader.next() {
+                if field.number == 1, case .varint(let type) = field.value { listType = type; break }
+            }
+            if listType == stringListType {
+                if let map = richTextMap(object, objects: objects) { richMaps[object.identifier] = map }
+            } else if listType == inlineListType {
+                if let map = inlineTextMap(object) { inlineMaps[object.identifier] = map }
+            }
         }
 
         var byTile: [UInt64: String] = [:]
@@ -406,16 +416,30 @@ enum IWATable {
         return Double(bitPattern: bits)
     }
 
-    /// Formats seconds-since-2001 (iWork's reference date) as `yyyy-MM-dd` in UTC.
-    /// Implausible magnitudes return "".
+    /// Formats seconds-since-2001 (iWork's reference date) as `yyyy-MM-dd`.
+    /// Computed arithmetically — no `DateFormatter`, which is allocation-free and
+    /// avoids a shared static formatter (not `Sendable` under Swift 6). Implausible
+    /// magnitudes return "".
     private static func isoDate(_ secondsSinceReference: Double) -> String {
         guard secondsSinceReference.isFinite, abs(secondsSinceReference) < 4e11 else { return "" }
-        let date = Date(timeIntervalSinceReferenceDate: secondsSinceReference)
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(identifier: "UTC")
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: date)
+        // Days since 1970-01-01 (2001-01-01 is 11_323 days after 1970-01-01).
+        let days = Int((secondsSinceReference / 86_400).rounded(.down)) + 11_323
+        // Howard Hinnant's civil-from-days algorithm.
+        let z = days + 719_468
+        let era = (z >= 0 ? z : z - 146_096) / 146_097
+        let doe = z - era * 146_097
+        let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365
+        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100)
+        let mp = (5 * doy + 2) / 153
+        let day = doy - (153 * mp + 2) / 5 + 1
+        let month = mp < 10 ? mp + 3 : mp - 9
+        let year = yoe + era * 400 + (month <= 2 ? 1 : 0)
+        func pad(_ value: Int, _ width: Int) -> String {
+            var string = String(value)
+            while string.count < width { string = "0" + string }
+            return string
+        }
+        return "\(pad(year, 4))-\(pad(month, 2))-\(pad(day, 2))"
     }
 
     // MARK: - Markdown rendering

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -66,11 +66,12 @@ enum IWATable {
 
     /// Markdown for every reconstructed table reachable from the given slide
     /// objects, in slide-then-discovery order (deduped). Used by Keynote to append
-    /// only tables that belong to real slides: a theme/master placeholder table,
-    /// whose Tile/DataList objects live in shared streams (not master-named
-    /// components), isn't reachable from any real slide and so is excluded —
-    /// filtering by the object graph rather than by component filename.
-    static func tablesReachableFromSlides(slideIDs: [UInt64], in streams: [[UInt8]]) -> [String] {
+    /// only tables that belong to real slides. `blocked` holds master/template
+    /// object ids the walk must not descend into: a real slide references its
+    /// template directly, so without that block its placeholder tables (which live
+    /// in shared streams, not master-named components) would be pulled in.
+    static func tablesReachableFromSlides(slideIDs: [UInt64], in streams: [[UInt8]],
+                                          excludingSubgraphs blocked: Set<UInt64>) -> [String] {
         let objects = buildObjects(streams)
         let tableMarkdown = reconstructTables(objects)
         guard !tableMarkdown.isEmpty else { return [] }
@@ -79,7 +80,7 @@ enum IWATable {
         var result: [String] = []
         var seen = Set<UInt64>()
         for slideID in slideIDs {
-            for tile in reachableTiles(from: slideID, objects: objects, tiles: tiles)
+            for tile in reachableTiles(from: slideID, objects: objects, tiles: tiles, blocked: blocked)
             where seen.insert(tile).inserted {
                 if let markdown = tableMarkdown[tile] { result.append(markdown) }
             }
@@ -89,11 +90,12 @@ enum IWATable {
 
     /// Bounded breadth-first walk from a root object collecting every
     /// reconstructed table's tile reachable from it (a slide → its drawables →
-    /// TableInfo → model → tile), in discovery order. Depth-bounded so the walk
-    /// stays within a slide's own content subgraph rather than fanning out through
-    /// shared objects to unrelated tables.
+    /// TableInfo → model → tile), in discovery order. References in `blocked`
+    /// (master/template objects) are not traversed, so a slide can't reach its
+    /// template's tables. Depth-bounded so the walk stays within a slide's own
+    /// content subgraph rather than fanning out through shared objects.
     private static func reachableTiles(from root: UInt64, objects: [UInt64: IWAArchive.Object],
-                                       tiles: Set<UInt64>) -> [UInt64] {
+                                       tiles: Set<UInt64>, blocked: Set<UInt64>) -> [UInt64] {
         var frontier = [root]
         var visited: Set<UInt64> = [root]
         var found: [UInt64] = []
@@ -101,7 +103,7 @@ enum IWATable {
             var next: [UInt64] = []
             for id in frontier {
                 guard let object = objects[id] else { continue }
-                for reference in object.references {
+                for reference in object.references where !blocked.contains(reference) {
                     if tiles.contains(reference), !found.contains(reference) { found.append(reference) }
                     if visited.insert(reference).inserted { next.append(reference) }
                 }

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -64,6 +64,54 @@ enum IWATable {
         return byTile.keys.sorted().compactMap { byTile[$0] }
     }
 
+    /// Markdown for every reconstructed table reachable from the given slide
+    /// objects, in slide-then-discovery order (deduped). Used by Keynote to append
+    /// only tables that belong to real slides: a theme/master placeholder table,
+    /// whose Tile/DataList objects live in shared streams (not master-named
+    /// components), isn't reachable from any real slide and so is excluded —
+    /// filtering by the object graph rather than by component filename.
+    static func tablesReachableFromSlides(slideIDs: [UInt64], in streams: [[UInt8]]) -> [String] {
+        let objects = buildObjects(streams)
+        let tableMarkdown = reconstructTables(objects)
+        guard !tableMarkdown.isEmpty else { return [] }
+        let tiles = Set(tableMarkdown.keys)
+
+        var result: [String] = []
+        var seen = Set<UInt64>()
+        for slideID in slideIDs {
+            for tile in reachableTiles(from: slideID, objects: objects, tiles: tiles)
+            where seen.insert(tile).inserted {
+                if let markdown = tableMarkdown[tile] { result.append(markdown) }
+            }
+        }
+        return result
+    }
+
+    /// Bounded breadth-first walk from a root object collecting every
+    /// reconstructed table's tile reachable from it (a slide → its drawables →
+    /// TableInfo → model → tile), in discovery order. Depth-bounded so the walk
+    /// stays within a slide's own content subgraph rather than fanning out through
+    /// shared objects to unrelated tables.
+    private static func reachableTiles(from root: UInt64, objects: [UInt64: IWAArchive.Object],
+                                       tiles: Set<UInt64>) -> [UInt64] {
+        var frontier = [root]
+        var visited: Set<UInt64> = [root]
+        var found: [UInt64] = []
+        for _ in 0 ..< 12 {
+            var next: [UInt64] = []
+            for id in frontier {
+                guard let object = objects[id] else { continue }
+                for reference in object.references {
+                    if tiles.contains(reference), !found.contains(reference) { found.append(reference) }
+                    if visited.insert(reference).inserted { next.append(reference) }
+                }
+            }
+            if next.isEmpty { break }
+            frontier = next
+        }
+        return found
+    }
+
     /// Splits the document body into ordered text/table blocks, placing each
     /// reconstructed table inline at its ￼ (U+FFFC) attachment position. Returns
     /// nil — so the caller can fall back to appended tables — unless every

--- a/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
@@ -107,17 +107,18 @@ public struct KeynoteConverter: DocumentConverter {
             if !cleaned.isEmpty { sections = [DocumentSection(kind: .body, markdown: cleaned)] }
         }
 
-        // Reconstruct tables from the deck's slide and shared components (table
-        // cells live in separate Tile/DataList objects) and append them after the
-        // slides. Master/template components are excluded — as for slide text — so
-        // theme placeholder tables don't leak in. Per-slide inline placement is a
+        // Reconstruct tables and append them after the slides, in deck order.
+        // Tables are filtered by reachability from the ordered slide objects: a
+        // theme/master placeholder table (whose Tile/DataList objects live in
+        // shared streams, not master-named components) isn't reachable from any
+        // real slide, so it can't leak in. Per-slide inline placement is a
         // follow-up.
         var deckStreams: [[UInt8]] = []
-        for component in components where !Self.isMaster(component.name) {
+        for component in components {
             try Task.checkCancellation()
             if let stream = try? Snappy.decompressIWA(component.bytes) { deckStreams.append(stream) }
         }
-        for markdown in IWATable.markdownTables(from: deckStreams) {
+        for markdown in IWATable.tablesReachableFromSlides(slideIDs: ordered.map(\.id), in: deckStreams) {
             sections.append(DocumentSection(kind: .table, markdown: markdown, sourcePath: "Index/Tables"))
         }
 

--- a/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
@@ -107,18 +107,25 @@ public struct KeynoteConverter: DocumentConverter {
             if !cleaned.isEmpty { sections = [DocumentSection(kind: .body, markdown: cleaned)] }
         }
 
-        // Reconstruct tables and append them after the slides, in deck order.
-        // Tables are filtered by reachability from the ordered slide objects: a
-        // theme/master placeholder table (whose Tile/DataList objects live in
-        // shared streams, not master-named components) isn't reachable from any
-        // real slide, so it can't leak in. Per-slide inline placement is a
-        // follow-up.
+        // Reconstruct tables and append them after the slides, in deck order,
+        // filtered by reachability from the ordered slide objects — without
+        // descending into master/template subgraphs (a real slide references its
+        // template, which may carry placeholder tables). Per-slide inline
+        // placement is a follow-up.
         var deckStreams: [[UInt8]] = []
+        var masterObjectIDs: Set<UInt64> = []
         for component in components {
             try Task.checkCancellation()
-            if let stream = try? Snappy.decompressIWA(component.bytes) { deckStreams.append(stream) }
+            guard let stream = try? Snappy.decompressIWA(component.bytes) else { continue }
+            deckStreams.append(stream)
+            if Self.isMaster(component.name) {
+                for object in IWAArchive.objects(in: stream) { masterObjectIDs.insert(object.identifier) }
+            }
         }
-        for markdown in IWATable.tablesReachableFromSlides(slideIDs: ordered.map(\.id), in: deckStreams) {
+        let deckTables = IWATable.tablesReachableFromSlides(
+            slideIDs: ordered.map(\.id), in: deckStreams, excludingSubgraphs: masterObjectIDs
+        )
+        for markdown in deckTables {
             sections.append(DocumentSection(kind: .table, markdown: markdown, sourcePath: "Index/Tables"))
         }
 

--- a/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
@@ -107,11 +107,13 @@ public struct KeynoteConverter: DocumentConverter {
             if !cleaned.isEmpty { sections = [DocumentSection(kind: .body, markdown: cleaned)] }
         }
 
-        // Reconstruct tables from the whole deck (table cells live in separate
-        // Tile/DataList objects) and append them after the slides. Per-slide inline
-        // placement is a follow-up.
+        // Reconstruct tables from the deck's slide and shared components (table
+        // cells live in separate Tile/DataList objects) and append them after the
+        // slides. Master/template components are excluded — as for slide text — so
+        // theme placeholder tables don't leak in. Per-slide inline placement is a
+        // follow-up.
         var deckStreams: [[UInt8]] = []
-        for component in components {
+        for component in components where !Self.isMaster(component.name) {
             try Task.checkCancellation()
             if let stream = try? Snappy.decompressIWA(component.bytes) { deckStreams.append(stream) }
         }

--- a/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/KeynoteConverter.swift
@@ -14,8 +14,10 @@
 //  as Pages) becomes one section, in deck order resolved from `Document.iwa`'s
 //  slide tree. Master/template slides are excluded, and presenter notes (`kind`
 //  4) are excluded by the `kind == 0` filter — both confirmed against a real
-//  `.key` (kinds: 0=body, 1=header/footer, 4=note, 5=cell). Per-slide
-//  title-vs-body structure, tables, and inline images remain follow-ups.
+//  `.key` (kinds: 0=body, 1=header/footer, 4=note, 5=cell). Tables are
+//  reconstructed (see IWATable) and appended after the slides; per-slide
+//  title-vs-body structure, inline images, and per-slide table placement remain
+//  follow-ups.
 //
 //  NOTE: `readEntry` / `normalize` mirror PagesConverter; a shared iWork helper
 //  is a planned cleanup once both converters have settled.
@@ -102,10 +104,22 @@ public struct KeynoteConverter: DocumentConverter {
                 if !text.isEmpty { pieces.append(text) }
             }
             let cleaned = Self.normalize(pieces.joined(separator: "\n\n"))
-            guard !cleaned.isEmpty else { throw PicoDocsError.emptyDocument }
-            sections = [DocumentSection(kind: .body, markdown: cleaned)]
+            if !cleaned.isEmpty { sections = [DocumentSection(kind: .body, markdown: cleaned)] }
         }
 
+        // Reconstruct tables from the whole deck (table cells live in separate
+        // Tile/DataList objects) and append them after the slides. Per-slide inline
+        // placement is a follow-up.
+        var deckStreams: [[UInt8]] = []
+        for component in components {
+            try Task.checkCancellation()
+            if let stream = try? Snappy.decompressIWA(component.bytes) { deckStreams.append(stream) }
+        }
+        for markdown in IWATable.markdownTables(from: deckStreams) {
+            sections.append(DocumentSection(kind: .table, markdown: markdown, sourcePath: "Index/Tables"))
+        }
+
+        guard !sections.isEmpty else { throw PicoDocsError.emptyDocument }
         let title = (info.filename?.isEmpty == false) ? info.filename : nil
         return ConverterResult(title: title, sections: sections)
     }

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -14,7 +14,8 @@
 //  inline at their attachment points in reading order (falling back to appending
 //  them after the body when attachments can't be mapped 1:1; see IWATable).
 //  Remaining rich structure (headings, styling, footnotes, inline images),
-//  non-text table cells (numbers/dates), the legacy iWork '09 XML format, and
+//  number/formula table cells (text and dates are decoded), the legacy iWork '09
+//  XML format, and
 //  ingesting a `.pages` *package directory* (an on-disk bundle, which the
 //  FileFetcher currently treats as a folder) are planned follow-ups; this
 //  converter raises a clear, actionable error for inputs it can't yet read

--- a/Tests/PicoDocsTests/KeynoteConverterTests.swift
+++ b/Tests/PicoDocsTests/KeynoteConverterTests.swift
@@ -121,17 +121,19 @@ struct KeynoteConverterTests {
         let result = try await PicoDocsEngine.convert(data: data, filename: "sample.key")
 
         let slides = result.sections.filter { $0.kind == .slide }
-        #expect(slides.count == 3)
-        #expect(slides.map(\.slideNumber) == [1, 2, 3])
+        #expect(slides.count == 5)
+        #expect(slides.map(\.slideNumber) == [1, 2, 3, 4, 5])
 
         // Deck order comes from Document.iwa's slide tree, NOT the filenames:
         // Slide.iwa ("The problem") is slide 2, not last. (Filename order would
-        // put it last and swap slides 2/3.)
+        // put it last and swap slides 2/3.) The two table slides follow.
         #expect(slides[0].markdown.contains("The Spoon"))
         #expect(slides[0].markdown.contains("Ronald Mannak"))
         #expect(slides[1].markdown.contains("The problem"))
         #expect(slides[1].markdown.contains("Every mug has a spoon-shaped absence"))
         #expect(slides[2].markdown.contains("The data"))
+        #expect(slides[3].markdown.contains("Table 1"))
+        #expect(slides[4].markdown.contains("Table 2"))
 
         // Presenter notes are kind 4 → excluded by the kind==0 filter; they must
         // not leak into slide text.
@@ -141,5 +143,12 @@ struct KeynoteConverterTests {
 
         // Object-replacement image placeholders are stripped.
         #expect(!markdown.unicodeScalars.contains("\u{FFFC}"))
+
+        // Tables are reconstructed and appended after the slides — text cells via
+        // the inline-text store, dates decoded from the cell record.
+        let tables = result.sections.filter { $0.kind == .table }
+        #expect(tables.count == 2)
+        #expect(tables.contains { $0.markdown.contains("| R1C1 | R1C2 | R1C3 | R1C4 |") })
+        #expect(tables.contains { $0.markdown.contains("| Item 1 | 2026-06-18 |") })
     }
 }

--- a/Tests/PicoDocsTests/PagesConverterTests.swift
+++ b/Tests/PicoDocsTests/PagesConverterTests.swift
@@ -121,8 +121,9 @@ struct PagesConverterTests {
         let result = try await PicoDocsEngine.convert(data: data, filename: "sample.pages")
         let tables = result.sections.filter { $0.kind == .table }
 
-        // Two content tables (5×4 and 4×6); two empty/placeholder tables are skipped.
-        #expect(tables.count == 2)
+        // Three content tables (5×4, 4×6, and the dates/formula table); empty
+        // placeholder tables are skipped.
+        #expect(tables.count == 3)
 
         // Table 1: exact header row, plus a body row exercising empty cells.
         #expect(tables.contains { $0.markdown.contains("| Feature | Expected import | Sample value | Notes |") })
@@ -132,6 +133,12 @@ struct PagesConverterTests {
         #expect(tables.contains {
             $0.markdown.contains("| Column A | Column B | Column C | Column D | Column E | Column F |")
         })
+
+        // Table 3: inline-text header (the "Date" column) and decoded date cells;
+        // numeric/formula cells aren't decoded yet and render empty.
+        #expect(tables.contains { $0.markdown.contains("| Column A | Date | Column B | Column C | Column D |") })
+        #expect(tables.contains { $0.markdown.contains("| Item 1 | 2026-06-18 |") })
+        #expect(tables.contains { $0.markdown.contains("2026-06-15") })
 
         // GitHub-flavored separator row for the four-column table.
         #expect(tables.contains { $0.markdown.contains("| --- | --- | --- | --- |") })


### PR DESCRIPTION
## Summary
Extended iWork table support to decode date cells and handle inline-text storage used by Keynote tables. Previously only rich-text cells were decoded; now the converter handles three cell value types (rich text, inline text, and dates) and reconstructs tables from both storage formats.

## Key Changes

- **Date cell decoding**: Added support for date cells (value-type `0x05`) stored as doubles representing seconds since 2001-01-01, formatted as ISO 8601 dates (`yyyy-MM-dd`)

- **Inline-text storage**: Implemented `inlineTextMap()` to handle `list_type == 1` DataLists where text is stored directly in entries, used by Keynote and some Pages cells, complementing the existing rich-text (`list_type == 8`) support

- **Cell value-type dispatch**: Refactored cell reading to dispatch on the value-type byte at offset +1 in cell records (`0x09` for rich text, `0x03` for inline text, `0x05` for dates) rather than assuming all cells are rich-text

- **Unified cell grid rendering**: Changed `cellKeyGrid()` to `cellGrid()` that directly produces rendered strings by resolving keys through both text maps and decoding dates, eliminating the intermediate key-lookup step

- **Keynote table extraction**: Updated `KeynoteConverter` to reconstruct and append tables after slides (per-slide inline placement deferred as a follow-up)

- **Test coverage**: Updated test expectations to verify date decoding and inline-text table reconstruction in both Pages and Keynote fixtures

## Implementation Details

- Added helper functions `readUInt32()` and `readDouble()` for safe binary reads with bounds checking
- Added `isoDate()` formatter using UTC timezone and POSIX locale for consistent date output
- Cell text now returns empty string `""` (present-but-empty cell) for unhandled types or read errors, distinguishing from `nil` (absent cell)
- Trailing absent columns are trimmed per row; empty/placeholder tables are still skipped during rendering
- Number, duration, and formula cells remain unimplemented and render as empty cells

https://claude.ai/code/session_01Mxnj6jvuLX9VS9JsJJbjmf