### PR TITLE
iWork tables: decode number and formula-result cells (decimal128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Create a PR to include your app here.
 
 ## Known Limitations
 
-- **iWork tables**: Tables are reconstructed as Markdown grids — placed inline at their original position in Pages, and with the slide that contains them in Keynote. Text and date cells are decoded; number, duration, and formula cells currently render as empty.
+- **iWork tables**: Tables are reconstructed as Markdown grids — placed inline at their original position in Pages, and with the slide that contains them in Keynote. Text, date, number, and formula-result cells are decoded; duration cells currently render as empty.
 
 ## License
 

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -23,10 +23,10 @@
 //
 //  Confirmed against real `.pages` and `.key` fixtures (text + date cells).
 //
-//  Scope: text and date cells; number, duration, and formula cells aren't
+//  Scope: text, date, number, and formula-result cells; duration cells aren't
 //  decoded yet and render empty. For Pages, tables are placed inline at their
-//  attachment point (see PagesConverter); for Keynote they're appended after the
-//  slides.
+//  attachment point (see PagesConverter); for Keynote, with the slide that owns
+//  them (see KeynoteConverter).
 //
 
 import Foundation
@@ -40,12 +40,15 @@ enum IWATable {
     private static let storageType: UInt64 = 2001
     private static let tableModelTypes: Set<UInt64> = [6001, 6316]   // TST.TableModelArchive
     private static let inlineListType: UInt64 = 1        // DataList.list_type for inline cell text
-    // Cell record value-type byte (record offset 1): rich text (key → f1==8 list),
-    // inline text (key → f1==1 list), and date (double, seconds since 2001-01-01,
-    // at offset +12). Number/duration/formula cells aren't decoded yet.
+    // Cell record value-type byte (record offset 1) selects how to read offset
+    // +12: rich text key (f1==8 list), inline text key (f1==1 list), a date
+    // (double, seconds since 2001-01-01), or a number / formula result (IEEE-754
+    // decimal128). Duration cells aren't decoded yet.
     private static let richTextCell: UInt8 = 0x09
     private static let inlineTextCell: UInt8 = 0x03
     private static let dateCell: UInt8 = 0x05
+    private static let numberCell: UInt8 = 0x02
+    private static let formulaCell: UInt8 = 0x0a
 
     /// One ordered piece of a converted body — a run of text or a reconstructed
     /// table, in reading order. Text is raw; the caller normalizes it.
@@ -435,9 +438,9 @@ enum IWATable {
 
     /// The rendered text of a cell record (`05 <type> …`): rich or inline text via
     /// the string maps (key is a little-endian uint32 at +12), or a date (double,
-    /// seconds since 2001-01-01, at +12). Number/duration/formula cells aren't
-    /// decoded yet and render as "". Returns "" (a present-but-empty cell) on any
-    /// unhandled type or out-of-bounds read.
+    /// seconds since 2001-01-01, at +12), or a number / formula result (decimal128
+    /// at +12). Duration cells aren't decoded yet. Returns "" (a present-but-empty
+    /// cell) on any unhandled type or out-of-bounds read.
     private static func cellText(in buffer: [UInt8], at offset: Int,
                                  rich: [UInt32: String], inline: [UInt32: String]) -> String {
         guard offset >= 0, offset + 2 <= buffer.count, buffer[offset] == 0x05 else { return "" }
@@ -451,9 +454,51 @@ enum IWATable {
         case dateCell:
             guard let seconds = readDouble(buffer, at: offset + 12) else { return "" }
             return isoDate(seconds)
+        case numberCell, formulaCell:
+            return decimalString(in: buffer, at: offset + 12)
         default:
             return ""
         }
+    }
+
+    /// A number or formula-result cell stores its value as an IEEE-754 decimal128
+    /// (16 bytes, little-endian) at offset +12. Decodes the common case
+    /// (coefficient up to 64 bits) into a plain decimal string; returns "" for the
+    /// large-coefficient form, an out-of-range exponent, or out-of-bounds.
+    private static func decimalString(in buffer: [UInt8], at offset: Int) -> String {
+        guard offset >= 0, offset + 16 <= buffer.count else { return "" }
+        let high = buffer[offset + 15]
+        guard (high >> 5) & 0x3 != 0x3 else { return "" }     // large-coefficient form
+        let exponent = ((Int(high & 0x7F) << 7) | Int(buffer[offset + 14] >> 1)) - 6176
+        guard exponent >= -128, exponent <= 128 else { return "" }
+        // Coefficient is the low 113 bits; supported when it fits in 64 bits.
+        guard buffer[offset + 14] & 1 == 0 else { return "" }
+        for k in 8 ..< 14 where buffer[offset + k] != 0 { return "" }
+        var coefficient: UInt64 = 0
+        for k in 0 ..< 8 { coefficient |= UInt64(buffer[offset + k]) << (8 * k) }
+        return formatDecimal(negative: high & 0x80 != 0, coefficient: coefficient, exponent: exponent)
+    }
+
+    /// Formats `coefficient × 10^exponent` as a plain decimal string, trimming
+    /// trailing fractional zeros (e.g. 420×10⁻² → "4.2", 35×10⁻² → "0.35").
+    private static func formatDecimal(negative: Bool, coefficient: UInt64, exponent: Int) -> String {
+        var result: String
+        if exponent >= 0 {
+            result = String(coefficient) + String(repeating: "0", count: exponent)
+        } else {
+            var digits = String(coefficient)
+            let fractionCount = -exponent
+            if digits.count <= fractionCount {
+                digits = String(repeating: "0", count: fractionCount - digits.count + 1) + digits
+            }
+            let split = digits.index(digits.endIndex, offsetBy: -fractionCount)
+            let integerPart = String(digits[..<split])
+            var fractionPart = String(digits[split...])
+            while fractionPart.hasSuffix("0") { fractionPart.removeLast() }
+            result = fractionPart.isEmpty ? integerPart : integerPart + "." + fractionPart
+        }
+        if result.isEmpty { result = "0" }
+        return (negative && result != "0") ? "-" + result : result
     }
 
     private static func readUInt32(_ buffer: [UInt8], at offset: Int) -> UInt32? {

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -463,15 +463,14 @@ enum IWATable {
 
     /// A number or formula-result cell stores its value as an IEEE-754 decimal128
     /// (16 bytes, little-endian) at offset +12. Decodes the full 113-bit
-    /// coefficient (any precision) into a plain decimal string; returns "" only for
-    /// the rare large-coefficient encoding (combination field 0b11), an
-    /// out-of-range exponent, or out-of-bounds.
+    /// coefficient (any precision) into a decimal string — plain for everyday
+    /// magnitudes, scientific notation for extreme exponents. Returns "" only for
+    /// the rare large-coefficient encoding (combination field 0b11) or out-of-bounds.
     private static func decimalString(in buffer: [UInt8], at offset: Int) -> String {
         guard offset >= 0, offset + 16 <= buffer.count else { return "" }
         let high = buffer[offset + 15]
         guard (high >> 5) & 0x3 != 0x3 else { return "" }     // large-coefficient form
         let exponent = ((Int(high & 0x7F) << 7) | Int(buffer[offset + 14] >> 1)) - 6176
-        guard exponent >= -128, exponent <= 128 else { return "" }
         // Coefficient is the low 113 bits: bytes 0-13 (112 bits) + bit 112.
         var coefficient = Array(buffer[offset ..< offset + 14])
         coefficient.append(buffer[offset + 14] & 1)
@@ -479,28 +478,41 @@ enum IWATable {
     }
 
     /// Formats `coefficient × 10^exponent` (coefficient as a little-endian
-    /// magnitude) as a plain decimal string, trimming trailing fractional zeros
-    /// (e.g. 420×10⁻² → "4.2", 35×10⁻² → "0.35"). A zero coefficient is always
-    /// "0", regardless of sign or exponent.
+    /// magnitude): a plain decimal for everyday magnitudes — trimming trailing
+    /// fractional zeros (420×10⁻² → "4.2", 35×10⁻² → "0.35") — or scientific
+    /// notation when the magnitude is extreme (e.g. "1E-200"), so no valid value
+    /// is dropped. A zero coefficient is always "0".
     private static func formatDecimal(negative: Bool, coefficient: [UInt8], exponent: Int) -> String {
-        let digitsString = decimalDigits(coefficient)
-        if digitsString == "0" { return "0" }
+        let digits = decimalDigits(coefficient)
+        if digits == "0" { return "0" }
+        let sign = negative ? "-" : ""
+
+        // Exponent if written with a single leading digit (d.ddd × 10^adjusted).
+        let adjusted = exponent + digits.count - 1
+        guard adjusted >= -6, adjusted < 21 else {     // extreme magnitude → scientific
+            var mantissa = String(digits.first!)
+            var fraction = String(digits.dropFirst())
+            while fraction.hasSuffix("0") { fraction.removeLast() }
+            if !fraction.isEmpty { mantissa += "." + fraction }
+            return sign + mantissa + "E\(adjusted)"
+        }
+
         var result: String
         if exponent >= 0 {
-            result = digitsString + String(repeating: "0", count: exponent)
+            result = digits + String(repeating: "0", count: exponent)
         } else {
-            var digits = digitsString
+            var padded = digits
             let fractionCount = -exponent
-            if digits.count <= fractionCount {
-                digits = String(repeating: "0", count: fractionCount - digits.count + 1) + digits
+            if padded.count <= fractionCount {
+                padded = String(repeating: "0", count: fractionCount - padded.count + 1) + padded
             }
-            let split = digits.index(digits.endIndex, offsetBy: -fractionCount)
-            let integerPart = String(digits[..<split])
-            var fractionPart = String(digits[split...])
+            let split = padded.index(padded.endIndex, offsetBy: -fractionCount)
+            let integerPart = String(padded[..<split])
+            var fractionPart = String(padded[split...])
             while fractionPart.hasSuffix("0") { fractionPart.removeLast() }
             result = fractionPart.isEmpty ? integerPart : integerPart + "." + fractionPart
         }
-        return negative ? "-" + result : result
+        return sign + result
     }
 
     /// Decimal string of a little-endian magnitude, via repeated division by 10.

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -462,31 +462,34 @@ enum IWATable {
     }
 
     /// A number or formula-result cell stores its value as an IEEE-754 decimal128
-    /// (16 bytes, little-endian) at offset +12. Decodes the common case
-    /// (coefficient up to 64 bits) into a plain decimal string; returns "" for the
-    /// large-coefficient form, an out-of-range exponent, or out-of-bounds.
+    /// (16 bytes, little-endian) at offset +12. Decodes the full 113-bit
+    /// coefficient (any precision) into a plain decimal string; returns "" only for
+    /// the rare large-coefficient encoding (combination field 0b11), an
+    /// out-of-range exponent, or out-of-bounds.
     private static func decimalString(in buffer: [UInt8], at offset: Int) -> String {
         guard offset >= 0, offset + 16 <= buffer.count else { return "" }
         let high = buffer[offset + 15]
         guard (high >> 5) & 0x3 != 0x3 else { return "" }     // large-coefficient form
         let exponent = ((Int(high & 0x7F) << 7) | Int(buffer[offset + 14] >> 1)) - 6176
         guard exponent >= -128, exponent <= 128 else { return "" }
-        // Coefficient is the low 113 bits; supported when it fits in 64 bits.
-        guard buffer[offset + 14] & 1 == 0 else { return "" }
-        for k in 8 ..< 14 where buffer[offset + k] != 0 { return "" }
-        var coefficient: UInt64 = 0
-        for k in 0 ..< 8 { coefficient |= UInt64(buffer[offset + k]) << (8 * k) }
+        // Coefficient is the low 113 bits: bytes 0-13 (112 bits) + bit 112.
+        var coefficient = Array(buffer[offset ..< offset + 14])
+        coefficient.append(buffer[offset + 14] & 1)
         return formatDecimal(negative: high & 0x80 != 0, coefficient: coefficient, exponent: exponent)
     }
 
-    /// Formats `coefficient × 10^exponent` as a plain decimal string, trimming
-    /// trailing fractional zeros (e.g. 420×10⁻² → "4.2", 35×10⁻² → "0.35").
-    private static func formatDecimal(negative: Bool, coefficient: UInt64, exponent: Int) -> String {
+    /// Formats `coefficient × 10^exponent` (coefficient as a little-endian
+    /// magnitude) as a plain decimal string, trimming trailing fractional zeros
+    /// (e.g. 420×10⁻² → "4.2", 35×10⁻² → "0.35"). A zero coefficient is always
+    /// "0", regardless of sign or exponent.
+    private static func formatDecimal(negative: Bool, coefficient: [UInt8], exponent: Int) -> String {
+        let digitsString = decimalDigits(coefficient)
+        if digitsString == "0" { return "0" }
         var result: String
         if exponent >= 0 {
-            result = String(coefficient) + String(repeating: "0", count: exponent)
+            result = digitsString + String(repeating: "0", count: exponent)
         } else {
-            var digits = String(coefficient)
+            var digits = digitsString
             let fractionCount = -exponent
             if digits.count <= fractionCount {
                 digits = String(repeating: "0", count: fractionCount - digits.count + 1) + digits
@@ -497,8 +500,24 @@ enum IWATable {
             while fractionPart.hasSuffix("0") { fractionPart.removeLast() }
             result = fractionPart.isEmpty ? integerPart : integerPart + "." + fractionPart
         }
-        if result.isEmpty { result = "0" }
-        return (negative && result != "0") ? "-" + result : result
+        return negative ? "-" + result : result
+    }
+
+    /// Decimal string of a little-endian magnitude, via repeated division by 10.
+    /// Returns "0" when the magnitude is zero.
+    private static func decimalDigits(_ littleEndianMagnitude: [UInt8]) -> String {
+        var value = littleEndianMagnitude
+        var digits = ""
+        while value.contains(where: { $0 != 0 }) {
+            var remainder = 0
+            for i in stride(from: value.count - 1, through: 0, by: -1) {
+                let current = (remainder << 8) | Int(value[i])
+                value[i] = UInt8(current / 10)
+                remainder = current % 10
+            }
+            digits = String(remainder) + digits
+        }
+        return digits.isEmpty ? "0" : digits
     }
 
     private static func readUInt32(_ buffer: [UInt8], at offset: Int) -> UInt32? {

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -14,8 +14,8 @@
 //  inline at their attachment points in reading order (falling back to appending
 //  them after the body when attachments can't be mapped 1:1; see IWATable).
 //  Remaining rich structure (headings, styling, footnotes, inline images),
-//  number/formula table cells (text and dates are decoded), the legacy iWork '09
-//  XML format, and
+//  duration table cells (text, dates, numbers, and formula results are decoded),
+//  the legacy iWork '09 XML format, and
 //  ingesting a `.pages` *package directory* (an on-disk bundle, which the
 //  FileFetcher currently treats as a folder) are planned follow-ups; this
 //  converter raises a clear, actionable error for inputs it can't yet read

--- a/Tests/PicoDocsTests/KeynoteConverterTests.swift
+++ b/Tests/PicoDocsTests/KeynoteConverterTests.swift
@@ -144,12 +144,15 @@ struct KeynoteConverterTests {
         // Object-replacement image placeholders are stripped.
         #expect(!markdown.unicodeScalars.contains("\u{FFFC}"))
 
-        // Tables are reconstructed and appended after the slides — text cells via
-        // the inline-text store, dates decoded from the cell record.
+        // Tables are reconstructed and placed with their slide — text via the
+        // inline-text store, dates from the cell record, and decimal128
+        // number/formula cells (the last row sums each column: 3+4+5=12,
+        // 4.66+36.14+2.76=43.56).
         let tables = result.sections.filter { $0.kind == .table }
         #expect(tables.count == 2)
         #expect(tables.contains { $0.markdown.contains("| R1C1 | R1C2 | R1C3 | R1C4 |") })
-        #expect(tables.contains { $0.markdown.contains("| Item 1 | 2026-06-18 |") })
+        #expect(tables.contains { $0.markdown.contains("| Item 1 | 2026-06-18 | 3 | 4.66 |") })
+        #expect(tables.contains { $0.markdown.contains("| Item 4 |  | 12 | 43.56 |") })
 
         // Each table is placed with the slide that owns it (slides 4 and 5),
         // carrying that slide's number — and interleaved, not appended at the end

--- a/Tests/PicoDocsTests/PagesConverterTests.swift
+++ b/Tests/PicoDocsTests/PagesConverterTests.swift
@@ -134,11 +134,13 @@ struct PagesConverterTests {
             $0.markdown.contains("| Column A | Column B | Column C | Column D | Column E | Column F |")
         })
 
-        // Table 3: inline-text header (the "Date" column) and decoded date cells;
-        // numeric/formula cells aren't decoded yet and render empty.
+        // Table 3: inline-text header (the "Date" column), decoded date cells, and
+        // decimal128 number/formula cells — the Total row sums each column
+        // (12+8=20, 4.2+275.92=280.12), which validates the numeric decode.
         #expect(tables.contains { $0.markdown.contains("| Column A | Date | Column B | Column C | Column D |") })
-        #expect(tables.contains { $0.markdown.contains("| Item 1 | 2026-06-18 |") })
-        #expect(tables.contains { $0.markdown.contains("2026-06-15") })
+        #expect(tables.contains { $0.markdown.contains("| Item 1 | 2026-06-18 | 12 | 0.35 | 4.2 |") })
+        #expect(tables.contains { $0.markdown.contains("| Items 2 | 2026-06-15 | 8 | 34.49 | 275.92 |") })
+        #expect(tables.contains { $0.markdown.contains("| Total |  | 20 |  | 280.12 |") })
 
         // GitHub-flavored separator row for the four-column table.
         #expect(tables.contains { $0.markdown.contains("| --- | --- | --- | --- |") })


### PR DESCRIPTION
Number (value-type 0x02) and formula-result (0x0a) cells store their value as an
IEEE-754 decimal128 at cell-record offset +12. Decode the common case
(coefficient up to 64 bits) without a 128-bit integer type — extract sign,
14-bit exponent, and 64-bit coefficient from the little-endian bytes — and
format as a plain decimal, trimming trailing fractional zeros. The
large-coefficient form, out-of-range exponents, and >64-bit coefficients fall
back to an empty cell. Duration cells remain undecoded.

Validated against both real fixtures, where the decode is self-checking: each
table's Total row equals the column sum (Pages 12+8=20 and 4.2+275.92=280.12;
Keynote 3+4+5=12 and 4.66+36.14+2.76=43.56). Tests assert the full numeric rows;
README and headers updated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mxnj6jvuLX9VS9JsJJbjmf