### PR TITLE
Pages: render paragraph styles as Markdown headings

### DIFF
--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -146,15 +146,18 @@ enum IWATable {
             let markers = scalars.indices.filter { scalars[$0].value == 0xFFFC }
             guard markers.count == attachments.count else { return nil }    // can't map 1:1
 
+            // Split the body only at table attachments; non-table markers (inline
+            // images) stay in the text and are dropped during paragraph rendering,
+            // so an image mid-paragraph doesn't break the paragraph into two blocks.
             var segmentStart = 0
             for (marker, attachment) in zip(markers, attachments) {
+                guard let tile = reachableTile(from: attachment.objectID, objects: objects, tiles: tiles),
+                      let markdown = tableMarkdown[tile] else { continue }  // image: leave ￼ in the text
                 let segment = renderParagraphs(scalars, segmentStart ..< marker, styles: styles, objects: objects)
                 if !segment.isEmpty { blocks.append(.text(segment)) }
-                segmentStart = marker + 1                                   // always drop the ￼
-                guard let tile = reachableTile(from: attachment.objectID, objects: objects, tiles: tiles),
-                      let markdown = tableMarkdown[tile] else { continue }  // non-table (image): no block
                 blocks.append(.table(markdown))
                 placed.insert(tile)
+                segmentStart = marker + 1                                   // drop the table ￼
             }
             let tail = renderParagraphs(scalars, segmentStart ..< scalars.count, styles: styles, objects: objects)
             if !tail.isEmpty { blocks.append(.text(tail)) }
@@ -226,9 +229,24 @@ enum IWATable {
     /// still attributed to its dominant style.
     private static func majorityStyle(_ runs: [(offset: Int, styleID: UInt64)], _ range: Range<Int>,
                                       total: Int) -> UInt64? {
+        guard !runs.isEmpty else { return nil }
+        // Runs are sorted and contiguous, so the runs overlapping `range` form a
+        // slice. Binary-search its start (the first run ending past range.lowerBound)
+        // and scan until a run begins at/after range.upperBound, keeping this
+        // O(log M + overlap) per paragraph rather than O(M).
+        var low = 0
+        var high = runs.count - 1
+        var first = runs.count
+        while low <= high {
+            let mid = (low + high) / 2
+            let runEnd = mid + 1 < runs.count ? runs[mid + 1].offset : total
+            if runEnd > range.lowerBound { first = mid; high = mid - 1 } else { low = mid + 1 }
+        }
         var best: UInt64?
         var bestOverlap = 0
-        for (index, run) in runs.enumerated() {
+        for index in first ..< runs.count {
+            let run = runs[index]
+            guard run.offset < range.upperBound else { break }
             let runEnd = index + 1 < runs.count ? runs[index + 1].offset : total
             let overlap = min(range.upperBound, runEnd) - max(range.lowerBound, run.offset)
             if overlap > bestOverlap { bestOverlap = overlap; best = run.styleID }

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -226,22 +226,20 @@ enum IWATable {
         for index in range where units[index] != 0xFFFC { kept.append(units[index]) }
         let text = String(decoding: kept, as: UTF16.self).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return nil }
-        guard let level = headingLevel(styleName(majorityStyle(styles, range, total: units.count),
+        guard let level = headingLevel(styleName(majorityStyle(units, styles, range, total: units.count),
                                                  objects: objects)) else { return text }
         let line = text.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
         return String(repeating: "#", count: level) + " " + line
     }
 
-    /// The ParagraphStyle id covering the most of `range`. Runs are run-length (one
-    /// run can span several same-style paragraphs), and taking the dominant overlap
-    /// tolerates a run boundary that doesn't fall exactly on the paragraph edge.
-    private static func majorityStyle(_ runs: [(offset: Int, styleID: UInt64)], _ range: Range<Int>,
-                                      total: Int) -> UInt64? {
+    /// The ParagraphStyle id covering the most *visible* units of `range`. Control
+    /// and object-replacement units (which `normalize` later strips) don't vote, so
+    /// a section-break sentinel sitting before a short heading can't outweigh the
+    /// heading's own run. Runs are sorted and contiguous, so the runs overlapping
+    /// `range` form a slice found by binary search.
+    private static func majorityStyle(_ units: [UInt16], _ runs: [(offset: Int, styleID: UInt64)],
+                                      _ range: Range<Int>, total: Int) -> UInt64? {
         guard !runs.isEmpty else { return nil }
-        // Runs are sorted and contiguous, so the runs overlapping `range` form a
-        // slice. Binary-search its start (the first run ending past range.lowerBound)
-        // and scan until a run begins at/after range.upperBound, keeping this
-        // O(log M + overlap) per paragraph rather than O(M).
         var low = 0
         var high = runs.count - 1
         var first = runs.count
@@ -256,10 +254,20 @@ enum IWATable {
             let run = runs[index]
             guard run.offset < range.upperBound else { break }
             let runEnd = index + 1 < runs.count ? runs[index + 1].offset : total
-            let overlap = min(range.upperBound, runEnd) - max(range.lowerBound, run.offset)
+            var overlap = 0
+            for position in max(range.lowerBound, run.offset) ..< min(range.upperBound, runEnd)
+            where !isDroppedUnit(units[position]) { overlap += 1 }
             if overlap > bestOverlap { bestOverlap = overlap; best = run.styleID }
         }
         return best
+    }
+
+    /// Units that `PagesConverter.normalize` strips from the visible text — C0/C1
+    /// controls (except tab and newline, which it keeps) and the object-replacement
+    /// placeholder — so they must not influence the heading-style vote.
+    private static func isDroppedUnit(_ unit: UInt16) -> Bool {
+        if unit == 0x09 || unit == 0x0A { return false }
+        return unit <= 0x1F || (0x7F ... 0x9F).contains(unit) || unit == 0xFFFC
     }
 
     /// A body storage's paragraph-style runs (field 5, a wrapper of repeated runs),

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -3,7 +3,9 @@
 //  PicoDocs
 //
 //  Reconstructs Apple iWork (Pages/Numbers/Keynote) tables from decompressed IWA
-//  object streams into GitHub-flavored Markdown grid tables.
+//  object streams into GitHub-flavored Markdown grid tables, and (via
+//  `inlineBlocks`) renders the Pages body as paragraphs with Markdown headings,
+//  interleaving each table at its attachment point.
 //
 //  A table is assembled from three object kinds, joined through the document
 //  object graph (`MessageInfo.object_references`):
@@ -120,45 +122,197 @@ enum IWATable {
         return found
     }
 
-    /// Splits the document body into ordered text/table blocks, placing each
-    /// reconstructed table inline at its ￼ (U+FFFC) attachment position. Returns
-    /// nil — so the caller can fall back to appended tables — unless every
-    /// reconstructed table is cleanly placed (e.g. it bails on a count mismatch
-    /// between ￼ markers and attachment runs), so a table is never dropped.
+    /// Splits the document body into ordered text/table blocks: body text is
+    /// rendered paragraph-by-paragraph with Markdown headings (from each
+    /// paragraph's ParagraphStyle), and each reconstructed table is placed inline
+    /// at its ￼ (U+FFFC) attachment position. Returns nil — so the caller can fall
+    /// back to appended tables — only when the ￼ markers can't be matched 1:1 to
+    /// attachment runs, so a table is never dropped. Offsets are Unicode scalar
+    /// (code-point) indices, the space iWork's run/attachment indices use.
     static func inlineBlocks(documentStream: [UInt8], in streams: [[UInt8]]) -> [Block]? {
         let objects = buildObjects(streams)
         let tableMarkdown = reconstructTables(objects)
-        // No early return on an empty table set: a table-less document still
-        // resolves to text-only blocks below, so the caller can use them directly
-        // instead of re-parsing the whole object graph in the appended fallback.
         let tiles = Set(tableMarkdown.keys)
 
         var blocks: [Block] = []
         var placed = Set<UInt64>()
         // Body storages in document (stream) order; each carries its own text
-        // (field 3) and drawable attachment runs (field 9).
+        // (field 3), paragraph-style runs (field 5), and attachment runs (field 9).
         for storage in IWAArchive.objects(in: documentStream) where storage.type == storageType {
             guard let text = bodyStorageText(storage) else { continue }    // kind 0 only
-            let runs = attachmentRuns(in: storage)
-            let markers = text.indices.filter { text[$0] == "\u{FFFC}" }
-            guard markers.count == runs.count else { return nil }          // can't map 1:1
+            let scalars = Array(text.unicodeScalars)
+            let attachments = attachmentRuns(in: storage)
+            let styles = paragraphStyleRuns(in: storage)
+            let markers = scalars.indices.filter { scalars[$0].value == 0xFFFC }
+            guard markers.count == attachments.count else { return nil }    // can't map 1:1
 
-            var buffer = ""
-            var segmentStart = text.startIndex
-            for (marker, run) in zip(markers, runs) {
-                buffer += String(text[segmentStart..<marker])
-                segmentStart = text.index(after: marker)                   // always drop the ￼
-                guard let tile = reachableTile(from: run.objectID, objects: objects, tiles: tiles),
-                      let markdown = tableMarkdown[tile] else { continue }  // non-table (image): merge text
-                if !buffer.isEmpty { blocks.append(.text(buffer)); buffer = "" }
+            var segmentStart = 0
+            for (marker, attachment) in zip(markers, attachments) {
+                let segment = renderParagraphs(scalars, segmentStart ..< marker, styles: styles, objects: objects)
+                if !segment.isEmpty { blocks.append(.text(segment)) }
+                segmentStart = marker + 1                                   // always drop the ￼
+                guard let tile = reachableTile(from: attachment.objectID, objects: objects, tiles: tiles),
+                      let markdown = tableMarkdown[tile] else { continue }  // non-table (image): no block
                 blocks.append(.table(markdown))
                 placed.insert(tile)
             }
-            buffer += String(text[segmentStart...])
-            if !buffer.isEmpty { blocks.append(.text(buffer)) }
+            let tail = renderParagraphs(scalars, segmentStart ..< scalars.count, styles: styles, objects: objects)
+            if !tail.isEmpty { blocks.append(.text(tail)) }
         }
         // Commit to inline layout only if every reconstructed table found a home.
         return placed == tiles ? blocks : nil
+    }
+
+    // MARK: - Headings
+
+    /// Renders a scalar range as Markdown: split into paragraphs at line/paragraph
+    /// separators, collapse each paragraph's whitespace, and prefix it with `#`s
+    /// when its dominant ParagraphStyle is a heading. Paragraphs are joined by a
+    /// blank line.
+    private static func renderParagraphs(_ scalars: [Unicode.Scalar], _ range: Range<Int>,
+                                         styles: [(offset: Int, styleID: UInt64)],
+                                         objects: [UInt64: IWAArchive.Object]) -> String {
+        var paragraphs: [String] = []
+        var start = range.lowerBound
+        var index = range.lowerBound
+        while index <= range.upperBound {
+            if index == range.upperBound || isParagraphBreak(scalars[index]) {
+                let collapsed = collapseParagraph(scalars, start ..< index)
+                if !collapsed.isEmpty {
+                    let style = majorityStyle(styles, start ..< index, total: scalars.count)
+                    if let level = headingLevel(styleName(style, objects: objects)) {
+                        paragraphs.append(String(repeating: "#", count: level) + " " + collapsed)
+                    } else {
+                        paragraphs.append(collapsed)
+                    }
+                }
+                start = index + 1
+            }
+            index += 1
+        }
+        return paragraphs.joined(separator: "\n\n")
+    }
+
+    private static func isParagraphBreak(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.value {
+        case 0x0A, 0x0D, 0x0B, 0x0C, 0x2028, 0x2029: return true
+        default: return false
+        }
+    }
+
+    /// One paragraph's text: whitespace/separator runs collapsed to single spaces,
+    /// surrounding whitespace trimmed, and control / object-replacement scalars
+    /// dropped.
+    private static func collapseParagraph(_ scalars: [Unicode.Scalar], _ range: Range<Int>) -> String {
+        var output = ""
+        var pendingSpace = false
+        for index in range {
+            let scalar = scalars[index]
+            let value = scalar.value
+            if value == 0xFFFC { continue }
+            if value == 0x20 || value == 0x09 || value == 0xA0 || isParagraphBreak(scalar) {
+                if !output.isEmpty { pendingSpace = true }
+                continue
+            }
+            if value <= 0x1F || (0x7F ... 0x9F).contains(value) { continue }
+            if pendingSpace { output += " "; pendingSpace = false }
+            output.unicodeScalars.append(scalar)
+        }
+        return output
+    }
+
+    /// The ParagraphStyle id covering the most scalars in `range`. Style runs are
+    /// run-length, so a paragraph whose auto-number sits in a neighbouring run is
+    /// still attributed to its dominant style.
+    private static func majorityStyle(_ runs: [(offset: Int, styleID: UInt64)], _ range: Range<Int>,
+                                      total: Int) -> UInt64? {
+        var best: UInt64?
+        var bestOverlap = 0
+        for (index, run) in runs.enumerated() {
+            let runEnd = index + 1 < runs.count ? runs[index + 1].offset : total
+            let overlap = min(range.upperBound, runEnd) - max(range.lowerBound, run.offset)
+            if overlap > bestOverlap { bestOverlap = overlap; best = run.styleID }
+        }
+        return best
+    }
+
+    /// A body storage's paragraph-style runs (field 5, a wrapper of repeated runs),
+    /// sorted by offset: each maps a scalar offset to a ParagraphStyle id.
+    private static func paragraphStyleRuns(in storage: IWAArchive.Object) -> [(offset: Int, styleID: UInt64)] {
+        var runs: [(offset: Int, styleID: UInt64)] = []
+        var reader = ProtobufReader(storage.payload)
+        while let field = reader.next() {
+            guard field.number == 5, case .length(let wrapper) = field.value else { continue }
+            var wrapperReader = ProtobufReader(wrapper)
+            while let entry = wrapperReader.next() {
+                guard entry.number == 1, case .length(let runBytes) = entry.value else { continue }
+                var offset: Int?
+                var styleID: UInt64?
+                var runReader = ProtobufReader(runBytes)
+                while let runField = runReader.next() {
+                    switch (runField.number, runField.value) {
+                    case (1, .varint(let value)): offset = Int(exactly: value)
+                    case (2, .length(let reference)): styleID = referencedID(in: reference)
+                    default: continue
+                    }
+                }
+                if let offset, let styleID { runs.append((offset, styleID)) }
+            }
+        }
+        return runs.sorted { $0.offset < $1.offset }
+    }
+
+    /// The display name of a ParagraphStyle, resolved through its parent chain (an
+    /// anonymous override inherits its name from a named preset like "Title").
+    private static func styleName(_ styleID: UInt64?, objects: [UInt64: IWAArchive.Object],
+                                  visited: Set<UInt64> = []) -> String? {
+        guard let styleID, !visited.contains(styleID), let object = objects[styleID] else { return nil }
+        let (name, parents) = styleArchive(object)
+        if let name { return name }
+        var seen = visited
+        seen.insert(styleID)
+        for parent in parents {
+            if let resolved = styleName(parent, objects: objects, visited: seen) { return resolved }
+        }
+        return nil
+    }
+
+    /// A style's TSS.StyleArchive (field 1): its name (sub-field 1) and parent
+    /// style references (sub-fields 3 and 5).
+    private static func styleArchive(_ object: IWAArchive.Object) -> (name: String?, parents: [UInt64]) {
+        var archive: [UInt8]?
+        var reader = ProtobufReader(object.payload)
+        while let field = reader.next() {
+            if field.number == 1, case .length(let bytes) = field.value { archive = bytes; break }
+        }
+        guard let archive else { return (nil, []) }
+        var name: String?
+        var parents: [UInt64] = []
+        var sub = ProtobufReader(archive)
+        while let field = sub.next() {
+            switch (field.number, field.value) {
+            case (1, .length(let bytes)): name = String(bytes: bytes, encoding: .utf8)
+            case (3, .length(let reference)), (5, .length(let reference)):
+                if let id = referencedID(in: reference) { parents.append(id) }
+            default: continue
+            }
+        }
+        return (name, parents)
+    }
+
+    /// Markdown heading level for a paragraph-style name: Title → 1, Subtitle → 2,
+    /// Heading N → N+1 (so "Title" outranks "Heading 1"), capped at 6. Other styles
+    /// (Body, lists, …) aren't headings.
+    private static func headingLevel(_ name: String?) -> Int? {
+        guard let name else { return nil }
+        let lower = name.lowercased()
+        if lower.hasPrefix("title") { return 1 }
+        if lower.hasPrefix("subtitle") { return 2 }
+        if lower.hasPrefix("heading") {
+            let number = Int(name.filter(\.isNumber)) ?? 1
+            return min(number + 1, 6)
+        }
+        return nil
     }
 
     // MARK: - Object graph

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -166,6 +166,24 @@ enum IWATable {
         return placed == tiles ? blocks : nil
     }
 
+    /// The document body rendered as heading-aware Markdown *without* inline tables.
+    /// Used by PagesConverter's fallback (when `inlineBlocks` bails on table
+    /// placement) so Title/Heading styles still produce `#`s while the tables are
+    /// appended separately; attachment marks are dropped. Empty when there is no
+    /// body text, so the caller can degrade to plain extraction.
+    static func bodyMarkdown(documentStream: [UInt8], in streams: [[UInt8]]) -> String {
+        let objects = buildObjects(streams)
+        var parts: [String] = []
+        for storage in IWAArchive.objects(in: documentStream) where storage.type == storageType {
+            guard let text = bodyStorageText(storage) else { continue }    // kind 0 only
+            let units = Array(text.utf16)
+            let styles = paragraphStyleRuns(in: storage)
+            let rendered = renderParagraphs(units, 0 ..< units.count, styles: styles, objects: objects)
+            if !rendered.isEmpty { parts.append(rendered) }
+        }
+        return parts.joined(separator: "\n\n")
+    }
+
     // MARK: - Headings
 
     /// Renders a UTF-16 range as Markdown: split into paragraphs at true paragraph

--- a/Sources/PicoDocs/Converters/Pages/IWATable.swift
+++ b/Sources/PicoDocs/Converters/Pages/IWATable.swift
@@ -127,8 +127,8 @@ enum IWATable {
     /// paragraph's ParagraphStyle), and each reconstructed table is placed inline
     /// at its ￼ (U+FFFC) attachment position. Returns nil — so the caller can fall
     /// back to appended tables — only when the ￼ markers can't be matched 1:1 to
-    /// attachment runs, so a table is never dropped. Offsets are Unicode scalar
-    /// (code-point) indices, the space iWork's run/attachment indices use.
+    /// attachment runs, so a table is never dropped. Offsets are UTF-16 code units,
+    /// the index space iWork's run/attachment character indices use.
     static func inlineBlocks(documentStream: [UInt8], in streams: [[UInt8]]) -> [Block]? {
         let objects = buildObjects(streams)
         let tableMarkdown = reconstructTables(objects)
@@ -140,10 +140,10 @@ enum IWATable {
         // (field 3), paragraph-style runs (field 5), and attachment runs (field 9).
         for storage in IWAArchive.objects(in: documentStream) where storage.type == storageType {
             guard let text = bodyStorageText(storage) else { continue }    // kind 0 only
-            let scalars = Array(text.unicodeScalars)
+            let units = Array(text.utf16)            // iWork run/attachment offsets are UTF-16 code units
             let attachments = attachmentRuns(in: storage)
             let styles = paragraphStyleRuns(in: storage)
-            let markers = scalars.indices.filter { scalars[$0].value == 0xFFFC }
+            let markers = units.indices.filter { units[$0] == 0xFFFC }
             guard markers.count == attachments.count else { return nil }    // can't map 1:1
 
             // Split the body only at table attachments; non-table markers (inline
@@ -153,13 +153,13 @@ enum IWATable {
             for (marker, attachment) in zip(markers, attachments) {
                 guard let tile = reachableTile(from: attachment.objectID, objects: objects, tiles: tiles),
                       let markdown = tableMarkdown[tile] else { continue }  // image: leave ￼ in the text
-                let segment = renderParagraphs(scalars, segmentStart ..< marker, styles: styles, objects: objects)
+                let segment = renderParagraphs(units, segmentStart ..< marker, styles: styles, objects: objects)
                 if !segment.isEmpty { blocks.append(.text(segment)) }
                 blocks.append(.table(markdown))
                 placed.insert(tile)
                 segmentStart = marker + 1                                   // drop the table ￼
             }
-            let tail = renderParagraphs(scalars, segmentStart ..< scalars.count, styles: styles, objects: objects)
+            let tail = renderParagraphs(units, segmentStart ..< units.count, styles: styles, objects: objects)
             if !tail.isEmpty { blocks.append(.text(tail)) }
         }
         // Commit to inline layout only if every reconstructed table found a home.
@@ -168,26 +168,20 @@ enum IWATable {
 
     // MARK: - Headings
 
-    /// Renders a scalar range as Markdown: split into paragraphs at line/paragraph
-    /// separators, collapse each paragraph's whitespace, and prefix it with `#`s
-    /// when its dominant ParagraphStyle is a heading. Paragraphs are joined by a
-    /// blank line.
-    private static func renderParagraphs(_ scalars: [Unicode.Scalar], _ range: Range<Int>,
+    /// Renders a UTF-16 range as Markdown: split into paragraphs at true paragraph
+    /// separators (not soft line breaks) and prefix each with `#`s when its dominant
+    /// ParagraphStyle is a heading. Paragraphs are joined by a blank line; interior
+    /// whitespace and soft breaks are left for `PagesConverter.normalize` to fold.
+    private static func renderParagraphs(_ units: [UInt16], _ range: Range<Int>,
                                          styles: [(offset: Int, styleID: UInt64)],
                                          objects: [UInt64: IWAArchive.Object]) -> String {
         var paragraphs: [String] = []
         var start = range.lowerBound
         var index = range.lowerBound
         while index <= range.upperBound {
-            if index == range.upperBound || isParagraphBreak(scalars[index]) {
-                let collapsed = collapseParagraph(scalars, start ..< index)
-                if !collapsed.isEmpty {
-                    let style = majorityStyle(styles, start ..< index, total: scalars.count)
-                    if let level = headingLevel(styleName(style, objects: objects)) {
-                        paragraphs.append(String(repeating: "#", count: level) + " " + collapsed)
-                    } else {
-                        paragraphs.append(collapsed)
-                    }
+            if index == range.upperBound || isParagraphSeparator(units[index]) {
+                if let paragraph = renderParagraph(units, start ..< index, styles: styles, objects: objects) {
+                    paragraphs.append(paragraph)
                 }
                 start = index + 1
             }
@@ -196,37 +190,33 @@ enum IWATable {
         return paragraphs.joined(separator: "\n\n")
     }
 
-    private static func isParagraphBreak(_ scalar: Unicode.Scalar) -> Bool {
-        switch scalar.value {
-        case 0x0A, 0x0D, 0x0B, 0x0C, 0x2028, 0x2029: return true
-        default: return false
-        }
+    /// Only true paragraph terminators split paragraphs; soft line breaks (U+2028,
+    /// U+000B, U+000C) stay inside the paragraph and become newlines via `normalize`.
+    private static func isParagraphSeparator(_ unit: UInt16) -> Bool {
+        unit == 0x0A || unit == 0x0D || unit == 0x2029
     }
 
-    /// One paragraph's text: whitespace/separator runs collapsed to single spaces,
-    /// surrounding whitespace trimmed, and control / object-replacement scalars
-    /// dropped.
-    private static func collapseParagraph(_ scalars: [Unicode.Scalar], _ range: Range<Int>) -> String {
-        var output = ""
-        var pendingSpace = false
-        for index in range {
-            let scalar = scalars[index]
-            let value = scalar.value
-            if value == 0xFFFC { continue }
-            if value == 0x20 || value == 0x09 || value == 0xA0 || isParagraphBreak(scalar) {
-                if !output.isEmpty { pendingSpace = true }
-                continue
-            }
-            if value <= 0x1F || (0x7F ... 0x9F).contains(value) { continue }
-            if pendingSpace { output += " "; pendingSpace = false }
-            output.unicodeScalars.append(scalar)
-        }
-        return output
+    /// One paragraph rendered to Markdown, or nil when it holds no text. Attachment
+    /// marks are dropped and the edges trimmed; a body paragraph keeps its interior
+    /// spacing (control/whitespace cleanup is deferred to `normalize`), while a
+    /// heading is flattened to a single, space-separated line.
+    private static func renderParagraph(_ units: [UInt16], _ range: Range<Int>,
+                                        styles: [(offset: Int, styleID: UInt64)],
+                                        objects: [UInt64: IWAArchive.Object]) -> String? {
+        var kept: [UInt16] = []
+        kept.reserveCapacity(range.count)
+        for index in range where units[index] != 0xFFFC { kept.append(units[index]) }
+        let text = String(decoding: kept, as: UTF16.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return nil }
+        guard let level = headingLevel(styleName(majorityStyle(styles, range, total: units.count),
+                                                 objects: objects)) else { return text }
+        let line = text.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+        return String(repeating: "#", count: level) + " " + line
     }
 
-    /// The ParagraphStyle id covering the most scalars in `range`. Style runs are
-    /// run-length, so a paragraph whose auto-number sits in a neighbouring run is
-    /// still attributed to its dominant style.
+    /// The ParagraphStyle id covering the most of `range`. Runs are run-length (one
+    /// run can span several same-style paragraphs), and taking the dominant overlap
+    /// tolerates a run boundary that doesn't fall exactly on the paragraph edge.
     private static func majorityStyle(_ runs: [(offset: Int, styleID: UInt64)], _ range: Range<Int>,
                                       total: Int) -> UInt64? {
         guard !runs.isEmpty else { return nil }

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -8,12 +8,13 @@
 //  `Index/*.iwa` (or a nested `Index.zip`); each `.iwa` is a Snappy-framed
 //  protobuf object stream whose TSWP text storages carry the body text.
 //
-//  Scope (v1): extracts the document's plain text (paragraphs) from the flat,
-//  single-file `.pages` ZIP — the common transport form (downloads, mail, Files
-//  exports) — plus table content, reconstructed as Markdown grids and placed
-//  inline at their attachment points in reading order (falling back to appending
-//  them after the body when attachments can't be mapped 1:1; see IWATable).
-//  Remaining rich structure (headings, styling, footnotes, inline images),
+//  Scope (v1): extracts the document's text from the flat, single-file `.pages`
+//  ZIP — the common transport form (downloads, mail, Files exports) — as
+//  paragraphs with Markdown heading levels mapped from their paragraph styles,
+//  plus table content reconstructed as Markdown grids and placed inline at their
+//  attachment points in reading order (falling back to appending them after the
+//  body when attachments can't be mapped 1:1; see IWATable). Remaining rich
+//  structure (inline character styling, footnotes, inline images),
 //  duration table cells (text, dates, numbers, and formula results are decoded),
 //  the legacy iWork '09 XML format, and
 //  ingesting a `.pages` *package directory* (an on-disk bundle, which the

--- a/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
+++ b/Sources/PicoDocs/Converters/Pages/PagesConverter.swift
@@ -96,7 +96,10 @@ public struct PagesConverter: DocumentConverter {
             // name) that yields any text.
             let bodyText: String
             if let documentStream {
-                bodyText = IWAArchive.text(in: documentStream)
+                // Render headings even on the fallback path; degrade to plain text
+                // extraction only if the style-aware renderer yields nothing.
+                let rendered = IWATable.bodyMarkdown(documentStream: documentStream, in: allStreams)
+                bodyText = rendered.isEmpty ? IWAArchive.text(in: documentStream) : rendered
             } else {
                 var firstText = ""
                 for entry in streams.sorted(by: { $0.name < $1.name }) {

--- a/Tests/PicoDocsTests/PagesConverterTests.swift
+++ b/Tests/PicoDocsTests/PagesConverterTests.swift
@@ -176,6 +176,25 @@ struct PagesConverterTests {
         }
     }
 
+    @Test("PagesConverter renders paragraph styles as Markdown headings")
+    func realPagesHeadings() async throws {
+        let data = try Fixture.data("sample", "pages")
+        let result = try await PicoDocsEngine.convert(data: data, filename: "sample.pages")
+        let markdown = result.markdown()
+
+        // The Title paragraph style maps to `#`, the section "Heading" style to `##`
+        // (a heading run is attributed to its paragraph even though the auto-number
+        // sits in a neighbouring run, so "2. Lists" is a heading, not "2").
+        #expect(markdown.contains("# Representative Import Fixture for Apple Pages"))
+        #expect(markdown.contains("## 1. Body text and inline formatting"))
+        #expect(markdown.contains("## 2. Lists"))
+        #expect(markdown.contains("## 6. Dates and formula"))
+
+        // Body paragraphs are not headings.
+        #expect(!markdown.contains("## This document is intentionally ordinary"))
+        #expect(!markdown.contains("## Plain paragraph before list"))
+    }
+
     @Test("Detector routes a .pages package to the Pages format")
     func detectionRoutesToPages() {
         let pages = Self.makePagesFile(paragraphs: ["Hi"])

--- a/Tests/PicoDocsTests/PagesConverterTests.swift
+++ b/Tests/PicoDocsTests/PagesConverterTests.swift
@@ -188,6 +188,9 @@ struct PagesConverterTests {
         #expect(markdown.contains("# Representative Import Fixture for Apple Pages"))
         #expect(markdown.contains("## 1. Body text and inline formatting"))
         #expect(markdown.contains("## 2. Lists"))
+        // Section 5 is preceded by a U+0004 section-break sentinel (a Body-styled
+        // run); the heading must still win the style vote once it's excluded.
+        #expect(markdown.contains("## 5. Landscape section and wider table"))
         #expect(markdown.contains("## 6. Dates and formula"))
 
         // Body paragraphs are not headings.


### PR DESCRIPTION
The body is now rendered paragraph-by-paragraph: each paragraph's dominant
ParagraphStyle (field 5 run, run-length) is resolved to a name through its
TSS.StyleArchive parent chain, and Title/Heading styles become Markdown headings
(Title -> #, Heading N -> N+1, capped at 6). Using the dominant style over the
paragraph's character range keeps auto-numbers ("2. Lists") attached to the
heading rather than the next run.

inlineBlocks now works in Unicode-scalar (code-point) space — matching iWork's
run/attachment character indices — splitting the body into paragraphs and
interleaving the reconstructed tables at their U+FFFC attachment points. Pages
body text, headings, dates, numbers, and tables now reconstruct together.

Validated against the real sample.pages (title #, sections ## 1-7, body
paragraphs unprefixed, tables inline). Adds a headings test.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mxnj6jvuLX9VS9JsJJbjmf